### PR TITLE
Document scaffolding with Doxygen docstrings

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -9,6 +9,7 @@ These instructions apply to the entire repository unless a nested `agents.md` ov
 
 ## Coding guidelines
 - Target Python 3.9+ and rely on the standard library only.
+- Write docstrings using Doxygen conventions (``"""!`` blocks with ``@brief`` and optional ``@details``) for modules, classes, and public functions.
 - Preserve cross-version uninstall support for MSI and Click-to-Run Office releases. Add constants/data-driven mappings instead of hard-coding logic when possible.
 - Guard destructive operations behind explicit flags as described in the spec (`--dry-run`, targeted scrubs, etc.).
 - Maintain structured logging (human + JSONL) consistent with `logging_ext` expectations.

--- a/office_janitor.py
+++ b/office_janitor.py
@@ -1,0 +1,38 @@
+"""!
+@brief Shim entry point for Office Janitor.
+@details This module ensures the package in ``src/`` is importable before
+transferring control to :func:`office_janitor.main.main`.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _prepend_src_to_sys_path() -> None:
+    """!
+    @brief Prepend the repository ``src`` directory to ``sys.path``.
+    @details The shim mirrors the structure described in :mod:`spec.md`, keeping
+    the distributable executable simple while letting the package live under
+    ``src/``.
+    """
+
+    repo_root = os.path.dirname(__file__)
+    src_path = os.path.join(repo_root, "src")
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+
+
+def main() -> int:
+    """!
+    @brief Invoke the package entry point after preparing ``sys.path``.
+    """
+
+    _prepend_src_to_sys_path()
+    from office_janitor.main import main as package_main
+
+    return package_main()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    sys.exit(main())

--- a/spec.md
+++ b/spec.md
@@ -20,6 +20,7 @@
 - **Language:** Python 3.9+ (works with 3.11+ too)
 - **Dependencies:** **None** beyond Python stdlib.
 - **Packaging:** PyInstaller **onefile**; include admin manifest.
+- **Documentation:** Use Doxygen-style docstrings (``"""!`` with ``@brief`` and related tags) throughout the codebase.
 
 ---
 

--- a/src/office_janitor/__init__.py
+++ b/src/office_janitor/__init__.py
@@ -1,0 +1,27 @@
+"""!
+@brief Office Janitor package root.
+@details Modules under this namespace coordinate detection, planning,
+uninstallation, and cleanup tasks for Microsoft Office installations per the
+project specification.
+"""
+
+__all__ = [
+    "main",
+    "detect",
+    "plan",
+    "scrub",
+    "msi_uninstall",
+    "c2r_uninstall",
+    "licensing",
+    "registry_tools",
+    "fs_tools",
+    "processes",
+    "tasks_services",
+    "logging_ext",
+    "restore_point",
+    "ui",
+    "tui",
+    "constants",
+    "safety",
+    "version",
+]

--- a/src/office_janitor/c2r_uninstall.py
+++ b/src/office_janitor/c2r_uninstall.py
@@ -1,0 +1,17 @@
+"""!
+@brief Click-to-Run uninstall orchestration utilities.
+@details The routines invoke ``OfficeC2RClient.exe`` and related tools to remove
+Click-to-Run Office releases while tracking progress and handling edge cases as
+outlined in the specification.
+"""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def uninstall_products(config: Mapping[str, str], *, dry_run: bool = False) -> None:
+    """!
+    @brief Trigger Click-to-Run uninstall sequences for the supplied configuration.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/constants.py
+++ b/src/office_janitor/constants.py
@@ -1,0 +1,28 @@
+"""!
+@brief Static data and enumerations for Office Janitor.
+@details Holds product code mappings, registry roots, default paths, and other
+constants used across detection, planning, and scrub orchestration per the
+specification.
+"""
+from __future__ import annotations
+
+SUPPORTED_VERSIONS = (
+    "2003",
+    "2007",
+    "2010",
+    "2013",
+    "2016",
+    "2019",
+    "2021",
+    "2024",
+    "365",
+)
+
+DEFAULT_OFFICE_PROCESSES = (
+    "winword.exe",
+    "excel.exe",
+    "outlook.exe",
+    "onenote.exe",
+    "visio.exe",
+    "powerpnt.exe",
+)

--- a/src/office_janitor/detect.py
+++ b/src/office_janitor/detect.py
@@ -1,0 +1,33 @@
+"""!
+@brief Detection helpers for installed Microsoft Office components.
+@details The detection pipeline queries registry hives, filesystem locations,
+and running processes to assemble an inventory of MSI and Click-to-Run Office
+deployments as described in the project specification.
+"""
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def detect_msi_installations() -> List[Dict[str, str]]:
+    """!
+    @brief Inspect the registry and return metadata for MSI-based Office installs.
+    """
+
+    raise NotImplementedError
+
+
+def detect_c2r_installations() -> List[Dict[str, str]]:
+    """!
+    @brief Probe Click-to-Run configuration to describe installed suites.
+    """
+
+    raise NotImplementedError
+
+
+def gather_office_inventory() -> Dict[str, List[Dict[str, str]]]:
+    """!
+    @brief Aggregate MSI, C2R, and ancillary signals into an inventory payload.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/fs_tools.py
+++ b/src/office_janitor/fs_tools.py
@@ -1,0 +1,26 @@
+"""!
+@brief Filesystem utilities for Office residue cleanup.
+@details Future implementations discover install footprints, reset ACLs, and
+remove leftovers from program directories and user profiles, matching the
+specification requirements.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+
+def remove_paths(paths: Iterable[Path], *, dry_run: bool = False) -> None:
+    """!
+    @brief Delete the supplied paths recursively while respecting dry-run behavior.
+    """
+
+    raise NotImplementedError
+
+
+def reset_acl(path: Path) -> None:
+    """!
+    @brief Reset permissions on ``path`` so cleanup operations can proceed.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/licensing.py
+++ b/src/office_janitor/licensing.py
@@ -1,0 +1,17 @@
+"""!
+@brief License and activation cleanup routines.
+@details This module handles SPP and OSPP token purges, scripts PowerShell
+helpers, and removes cached activation material according to the
+specification's safety constraints.
+"""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def cleanup_licenses(options: Mapping[str, object]) -> None:
+    """!
+    @brief Remove activation artifacts based on the requested cleanup options.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/logging_ext.py
+++ b/src/office_janitor/logging_ext.py
@@ -1,0 +1,21 @@
+"""!
+@brief Structured logging helpers for Office Janitor.
+@details When implemented this module configures human-readable logs alongside
+JSONL telemetry streams, optionally mirroring machine events to stdout as
+detailed in the specification.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Tuple
+
+
+def setup_logging(root_dir: Path, *, json_to_stdout: bool = False, level: int = logging.INFO) -> Tuple[logging.Logger, logging.Logger]:
+    """!
+    @brief Set up human and machine loggers.
+    @details The function returns a pair of ``logging.Logger`` objects
+    representing the human-readable and structured event channels respectively.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/main.py
+++ b/src/office_janitor/main.py
@@ -1,0 +1,171 @@
+"""!
+@brief Primary entry point for the Office Janitor CLI.
+@details This module bootstraps the runtime environment described in
+:mod:`spec.md`: argument parsing for detection and scrubbing modes, validating
+administrative elevation, enabling Windows VT mode when available, and invoking
+logging setup so future sub-systems can emit structured telemetry.
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import logging
+import os
+import pathlib
+import sys
+from typing import Iterable, Optional
+
+from . import logging_ext, version
+
+
+def enable_vt_mode_if_possible() -> None:
+    """!
+    @brief Attempt to enable ANSI/VT processing on Windows consoles.
+    @details Per the specification, the application should try to enable virtual
+    terminal support so both the plain CLI and future TUI renderer can emit
+    colorized output. Failures are silently ignored because the feature is
+    optional.
+    """
+
+    try:
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+        mode = wintypes.DWORD()
+        if kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            kernel32.SetConsoleMode(handle, mode.value | 0x0004)
+    except Exception:
+        # Non-Windows platforms or consoles without VT capability are fine.
+        return
+
+
+def ensure_admin_and_relaunch_if_needed() -> None:
+    """!
+    @brief Request elevation if the current process lacks administrative rights.
+    """
+
+    try:
+        is_admin = ctypes.windll.shell32.IsUserAnAdmin()  # type: ignore[attr-defined]
+    except Exception:
+        is_admin = False
+    if not is_admin and os.name == "nt":
+        params = " ".join(f'"{arg}"' for arg in sys.argv)
+        ctypes.windll.shell32.ShellExecuteW(  # type: ignore[attr-defined]
+            None, "runas", sys.executable, params, None, 1
+        )
+        sys.exit(0)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """!
+    @brief Create the top-level argument parser with the specification's surface area.
+    @details The parser wires in the mutually exclusive modes and shared options
+    defined in the specification so later feature work can hook into the parsed
+    values without changing the public CLI signature.
+    """
+
+    parser = argparse.ArgumentParser(prog="office-janitor", add_help=True)
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"{version.__version__} ({version.__build__})",
+    )
+
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument("--auto-all", action="store_true", help="Run full detection and scrub.")
+    modes.add_argument(
+        "--target",
+        metavar="VER",
+        help="Target a specific Office version (2003-2024/365).",
+    )
+    modes.add_argument("--diagnose", action="store_true", help="Emit inventory and plan without changes.")
+    modes.add_argument("--cleanup-only", action="store_true", help="Skip uninstalls; clean residue and licensing.")
+
+    parser.add_argument("--include", metavar="COMPONENTS", help="Additional suites/apps to include.")
+    parser.add_argument("--force", action="store_true", help="Relax certain guardrails when safe.")
+    parser.add_argument("--dry-run", action="store_true", help="Simulate actions without modifying the system.")
+    parser.add_argument("--no-restore-point", action="store_true", help="Skip creating a restore point.")
+    parser.add_argument("--no-license", action="store_true", help="Skip license cleanup steps.")
+    parser.add_argument("--keep-templates", action="store_true", help="Preserve user templates like normal.dotm.")
+    parser.add_argument("--plan", metavar="OUT", help="Write the computed action plan to a JSON file.")
+    parser.add_argument("--logdir", metavar="DIR", help="Directory for human/JSONL log output.")
+    parser.add_argument("--backup", metavar="DIR", help="Destination for registry/file backups.")
+    parser.add_argument("--timeout", metavar="SEC", type=int, help="Per-step timeout in seconds.")
+    parser.add_argument("--quiet", action="store_true", help="Minimal console output (errors only).")
+    parser.add_argument("--json", action="store_true", help="Mirror structured events to stdout.")
+    parser.add_argument("--tui", action="store_true", help="Force the interactive text UI mode.")
+    parser.add_argument("--no-color", action="store_true", help="Disable ANSI color codes.")
+    parser.add_argument("--tui-compact", action="store_true", help="Use a compact TUI layout for small consoles.")
+    parser.add_argument(
+        "--tui-refresh",
+        metavar="MS",
+        type=int,
+        help="Refresh interval for the TUI renderer in milliseconds.",
+    )
+    return parser
+
+
+def _resolve_log_directory(candidate: Optional[str]) -> pathlib.Path:
+    """!
+    @brief Determine the log directory path using specification defaults when unspecified.
+    """
+
+    if candidate:
+        return pathlib.Path(candidate).expanduser().resolve()
+    if os.name == "nt":
+        program_data = os.environ.get("ProgramData", r"C:\\ProgramData")
+        return pathlib.Path(program_data) / "OfficeJanitor" / "logs"
+    return pathlib.Path.cwd() / "logs"
+
+
+def _bootstrap_logging(args: argparse.Namespace) -> tuple[logging.Logger, logging.Logger]:
+    """!
+    @brief Initialize human and machine loggers, falling back if unimplemented.
+    """
+
+    logdir = _resolve_log_directory(getattr(args, "logdir", None))
+    try:
+        return logging_ext.setup_logging(logdir, json_to_stdout=getattr(args, "json", False))
+    except NotImplementedError:
+        logging.basicConfig(level=logging.INFO)
+        human = logging.getLogger("human")
+        machine = logging.getLogger("machine")
+        return human, machine
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    """!
+    @brief Entry point invoked by the shim and PyInstaller bundle.
+    """
+
+    ensure_admin_and_relaunch_if_needed()
+    enable_vt_mode_if_possible()
+    parser = build_arg_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    human_log, machine_log = _bootstrap_logging(args)
+
+    human_log.info("Office Janitor bootstrap complete; core logic not yet implemented.")
+    machine_log.info("startup", extra={"event": "startup", "data": {"mode": _determine_mode(args)}})
+    return 0
+
+
+def _determine_mode(args: argparse.Namespace) -> str:
+    """!
+    @brief Map parsed arguments to a simple textual mode identifier.
+    """
+
+    if getattr(args, "auto_all", False):
+        return "auto-all"
+    if getattr(args, "target", None):
+        return f"target:{args.target}"
+    if getattr(args, "diagnose", False):
+        return "diagnose"
+    if getattr(args, "cleanup_only", False):
+        return "cleanup-only"
+    return "interactive"
+
+
+if __name__ == "__main__":  # pragma: no cover - for manual execution
+    sys.exit(main())

--- a/src/office_janitor/msi_uninstall.py
+++ b/src/office_janitor/msi_uninstall.py
@@ -1,0 +1,17 @@
+"""!
+@brief Helpers for orchestrating MSI-based Office uninstalls.
+@details This module locates MSI product codes, drives ``msiexec`` with the
+correct flags, monitors progress, and captures logs according to the
+specification.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def uninstall_products(product_codes: Iterable[str], *, dry_run: bool = False) -> None:
+    """!
+    @brief Uninstall the supplied MSI product codes while respecting dry-run semantics.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/plan.py
+++ b/src/office_janitor/plan.py
@@ -1,0 +1,17 @@
+"""!
+@brief Translate detection results into actionable scrub plans.
+@details Planning resolves requested modes, target Office versions, and
+user-selected options into an ordered sequence of steps for uninstall, cleanup,
+and backups, matching the workflow outlined in the specification.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
+
+
+def build_plan(inventory: Dict[str, Sequence[dict]], options: Dict[str, object]) -> List[dict]:
+    """!
+    @brief Produce an ordered plan of actions using the current inventory and CLI options.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/processes.py
+++ b/src/office_janitor/processes.py
@@ -1,0 +1,17 @@
+"""!
+@brief Process and service control helpers.
+@details The process utilities terminate running Office binaries and pause
+background services that block uninstall operations, following the
+specification's safety and retry requirements.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def terminate_office_processes(names: Iterable[str], *, timeout: int = 30) -> None:
+    """!
+    @brief Stop known Office processes before uninstalling.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/registry_tools.py
+++ b/src/office_janitor/registry_tools.py
@@ -1,0 +1,25 @@
+"""!
+@brief Registry management helpers.
+@details The registry tools export hives for backup, delete targeted keys, and
+provide winreg utilities used throughout detection and cleanup as outlined in
+the specification.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def export_keys(keys: Iterable[str], destination: str) -> None:
+    """!
+    @brief Export the provided registry keys to ``.reg`` files in ``destination``.
+    """
+
+    raise NotImplementedError
+
+
+def delete_keys(keys: Iterable[str], *, dry_run: bool = False) -> None:
+    """!
+    @brief Remove registry keys while respecting dry-run safeguards.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/restore_point.py
+++ b/src/office_janitor/restore_point.py
@@ -1,0 +1,14 @@
+"""!
+@brief System restore point management.
+@details Creates restore points prior to destructive operations when supported,
+providing optional rollback coverage per the specification.
+"""
+from __future__ import annotations
+
+
+def create_restore_point(description: str) -> None:
+    """!
+    @brief Request a system restore point with the supplied description.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/safety.py
+++ b/src/office_janitor/safety.py
@@ -1,0 +1,16 @@
+"""!
+@brief Safety and guardrail enforcement.
+@details Implements dry-run, whitelist/blacklist checks, and preflight
+validation to keep cleanup actions safe as called for in the specification.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+
+def perform_preflight_checks(plan: Iterable[Mapping[str, object]]) -> None:
+    """!
+    @brief Validate that the plan satisfies safety requirements before execution.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/scrub.py
+++ b/src/office_janitor/scrub.py
@@ -1,0 +1,17 @@
+"""!
+@brief Orchestrate uninstallation, cleanup, and reporting steps.
+@details The scrubber consumes an action plan and coordinates MSI/C2R uninstall
+routines, license cleanup, filesystem and registry purges, and telemetry
+emission as laid out in the specification.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+
+def execute_plan(plan: Iterable[Mapping[str, object]], *, dry_run: bool = False) -> None:
+    """!
+    @brief Run each plan step while respecting dry-run safety requirements.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/tasks_services.py
+++ b/src/office_janitor/tasks_services.py
@@ -1,0 +1,25 @@
+"""!
+@brief Scheduled task and service management utilities.
+@details Implements discovery and cleanup of scheduled tasks, services, and
+related artifacts that keep Office components resident, matching the
+specification's guidelines.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def disable_tasks(task_names: Iterable[str], *, dry_run: bool = False) -> None:
+    """!
+    @brief Disable or remove scheduled tasks linked to Office.
+    """
+
+    raise NotImplementedError
+
+
+def stop_services(service_names: Iterable[str], *, timeout: int = 30) -> None:
+    """!
+    @brief Stop service processes before uninstall operations proceed.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/tui.py
+++ b/src/office_janitor/tui.py
@@ -1,0 +1,32 @@
+"""!
+@brief Text-based user interface (TUI) engine.
+@details Implements the ANSI/VT driven interface with panes, widgets, and event
+handling outlined in the specification for rich interactive sessions.
+"""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+class OfficeJanitorTUI:
+    """!
+    @brief Placeholder TUI controller coordinating rendering and event handling.
+    """
+
+    def __init__(self, app_state: Mapping[str, object]) -> None:
+        self.app_state = app_state
+
+    def run(self) -> None:
+        """!
+        @brief Enter the TUI event loop.
+        """
+
+        raise NotImplementedError
+
+
+def run_tui(app_state: Mapping[str, object]) -> None:
+    """!
+    @brief Convenience wrapper to create and run the TUI controller.
+    """
+
+    OfficeJanitorTUI(app_state).run()

--- a/src/office_janitor/ui.py
+++ b/src/office_janitor/ui.py
@@ -1,0 +1,16 @@
+"""!
+@brief Plain console user interface helpers.
+@details Provides the interactive menu experience described in the specification
+for environments that do not support the richer TUI renderer.
+"""
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def run_cli(app_state: Mapping[str, object]) -> None:
+    """!
+    @brief Launch the basic interactive console menu.
+    """
+
+    raise NotImplementedError

--- a/src/office_janitor/version.py
+++ b/src/office_janitor/version.py
@@ -1,0 +1,10 @@
+"""!
+@brief Version metadata for Office Janitor.
+@details The version module exposes build identifiers for CLI reporting and
+packaging integration, matching the specification's requirement for
+``-V/--version`` output.
+"""
+from __future__ import annotations
+
+__version__ = "0.0.0"
+__build__ = "dev"


### PR DESCRIPTION
## Summary
- convert the shim and all stub modules to use Doxygen-style docstrings so future implementations keep a consistent documentation format
- document the docstring requirement in the spec and repository agent guidelines for clarity

## Testing
- python office_janitor.py --help

------
https://chatgpt.com/codex/tasks/task_e_68fb9330a75883259cd3bb4a33d6d7fb