### PR TITLE
Add pytest scaffolding for spec areas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+"""!
+@brief Test package for office-janitor.
+@details Provides pytest-based test scaffolding aligned with the project specification.
+"""

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,0 +1,22 @@
+"""!
+@brief Detection scaffolding tests.
+@details Placeholder coverage for registry probing and detection heuristics defined in the spec.
+"""
+
+import pytest
+
+
+@pytest.mark.skip(reason="Placeholder for detection registry probing scenarios.")
+class TestRegistryDetectionScenarios:
+    """!
+    @brief Registry probing detection scenarios.
+    @details Will validate discovery of Office installations across registry hives, install roots, and
+    release channels once detection logic is implemented.
+    """
+
+    def test_registry_probe_placeholder(self) -> None:
+        """!
+        @brief Placeholder detection test.
+        @details Ensures discovery logic handles multiple Office versions and architecture combinations.
+        """
+        pytest.skip("Placeholder for detection registry probing scenarios.")

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,22 @@
+"""!
+@brief Planning scaffolding tests.
+@details Placeholder coverage for uninstall planning rules, sequencing, and remediation tactics.
+"""
+
+import pytest
+
+
+@pytest.mark.skip(reason="Placeholder for planning rule enforcement scenarios.")
+class TestPlanningRuleScenarios:
+    """!
+    @brief Planning rule validation scenarios.
+    @details Will verify dry-run plans, dependency ordering, and conflict resolution strategies once
+    planning logic is implemented.
+    """
+
+    def test_planning_rules_placeholder(self) -> None:
+        """!
+        @brief Placeholder planning test.
+        @details Ensures planner enforces guardrails such as SKU compatibility and required prerequisites.
+        """
+        pytest.skip("Placeholder for planning rule enforcement scenarios.")

--- a/tests/test_registry_tools.py
+++ b/tests/test_registry_tools.py
@@ -1,0 +1,23 @@
+"""!
+@brief Registry tooling scaffolding tests.
+@details Placeholder coverage for backup, export, and restore simulations across supported registries.
+"""
+
+import pytest
+
+
+@pytest.mark.skip(reason="Placeholder for registry backup and export scenarios.")
+class TestRegistryTooling:
+    """!
+    @brief Registry tool simulation scenarios.
+    @details Will validate backup/export orchestration, error handling, and cross-architecture registry
+    hive support once tooling logic is implemented.
+    """
+
+    def test_registry_tooling_placeholder(self) -> None:
+        """!
+        @brief Placeholder registry tooling test.
+        @details Ensures backup and export flows integrate with detection and planning stages without
+        side effects during simulations.
+        """
+        pytest.skip("Placeholder for registry backup and export scenarios.")

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,22 @@
+"""!
+@brief Safety scaffolding tests.
+@details Placeholder coverage for guardrail enforcement, fail-safes, and irreversible action controls.
+"""
+
+import pytest
+
+
+@pytest.mark.skip(reason="Placeholder for safety guardrail scenarios.")
+class TestSafetyGuardrails:
+    """!
+    @brief Safety guardrail scenarios.
+    @details Will confirm destructive operations remain gated behind explicit flags, backups, and
+    operator confirmations once safety logic exists.
+    """
+
+    def test_safety_guardrails_placeholder(self) -> None:
+        """!
+        @brief Placeholder safety test.
+        @details Ensures guardrails prevent unintended scrubbing or registry mutations during dry runs.
+        """
+        pytest.skip("Placeholder for safety guardrail scenarios.")


### PR DESCRIPTION
## Summary
- add a pytest-aware tests package with module docstrings that map to detection, planning, safety, and registry tooling areas from the spec
- configure pytest discovery through pyproject.toml so the new scaffolding participates in future test runs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fb9c5863608325b651a39db38eb0af