### PR TITLE
Add structured logging infrastructure and coverage

### DIFF
--- a/src/office_janitor/logging_ext.py
+++ b/src/office_janitor/logging_ext.py
@@ -1,21 +1,224 @@
 """!
 @brief Structured logging helpers for Office Janitor.
-@details When implemented this module configures human-readable logs alongside
-JSONL telemetry streams, optionally mirroring machine events to stdout as
-detailed in the specification.
+@details This module configures dual-channel logging consisting of a
+human-oriented rotating file and a machine-consumable JSONL stream. Callers can
+optionally mirror the machine stream to stdout for orchestration scenarios.
 """
 from __future__ import annotations
 
+import datetime as _dt
+import json
 import logging
+from logging import handlers
+import sys
 from pathlib import Path
-from typing import Tuple
+from typing import Dict, Iterable, Tuple
+
+HUMAN_LOGGER_NAME = "office_janitor.human"
+"""!
+@brief Logger name for human-readable output.
+"""
+
+MACHINE_LOGGER_NAME = "office_janitor.machine"
+"""!
+@brief Logger name for JSONL telemetry output.
+"""
+
+_STANDARD_RECORD_KEYS: Dict[str, None] = {
+    "name": None,
+    "msg": None,
+    "args": None,
+    "levelname": None,
+    "levelno": None,
+    "pathname": None,
+    "filename": None,
+    "module": None,
+    "exc_info": None,
+    "exc_text": None,
+    "stack_info": None,
+    "lineno": None,
+    "funcName": None,
+    "created": None,
+    "msecs": None,
+    "relativeCreated": None,
+    "thread": None,
+    "threadName": None,
+    "processName": None,
+    "process": None,
+    "message": None,
+    "asctime": None,
+    "channel": None,
+}
+
+_CURRENT_LOG_DIRECTORY: Path | None = None
 
 
-def setup_logging(root_dir: Path, *, json_to_stdout: bool = False, level: int = logging.INFO) -> Tuple[logging.Logger, logging.Logger]:
+class _ChannelFilter(logging.Filter):
     """!
-    @brief Set up human and machine loggers.
-    @details The function returns a pair of ``logging.Logger`` objects
-    representing the human-readable and structured event channels respectively.
+    @brief Inject a fixed ``channel`` attribute on log records.
+    @details The human and machine loggers rely on this filter so formatters can
+    emit a stable metadata field identifying the stream without callers needing
+    to provide ``extra`` parameters manually.
     """
 
-    raise NotImplementedError
+    def __init__(self, channel: str) -> None:
+        super().__init__()
+        self._channel = channel
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.channel = self._channel
+        return True
+
+
+class _JsonLineFormatter(logging.Formatter):
+    """!
+    @brief Format ``LogRecord`` instances as single-line JSON objects.
+    @details The formatter extracts standard metadata (timestamp, level, logger,
+    and message) and merges any custom ``extra`` attributes provided by callers.
+    Values that are not JSON serializable are coerced to their ``repr``.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - concise override
+        moment = _dt.datetime.fromtimestamp(record.created, tz=_dt.timezone.utc)
+        payload: Dict[str, object] = {
+            "timestamp": moment.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "channel": getattr(record, "channel", "machine"),
+        }
+
+        extras = _extract_extras(record)
+        payload.update(extras)
+        try:
+            return json.dumps(payload, ensure_ascii=False)
+        except TypeError:
+            sanitized = {key: _coerce_json(value) for key, value in payload.items()}
+            return json.dumps(sanitized, ensure_ascii=False)
+
+
+def _extract_extras(record: logging.LogRecord) -> Dict[str, object]:
+    """!
+    @brief Collect non-standard attributes from a log record.
+    """
+
+    extras: Dict[str, object] = {}
+    for key, value in record.__dict__.items():
+        if key in _STANDARD_RECORD_KEYS:
+            continue
+        extras[key] = value
+    return extras
+
+
+def _coerce_json(value: object) -> object:
+    """!
+    @brief Coerce arbitrary objects into a JSON-safe representation.
+    """
+
+    try:
+        json.dumps(value)
+    except TypeError:
+        return repr(value)
+    return value
+
+
+def _configure_logger(logger: logging.Logger, formatter: logging.Formatter, handlers_to_add: Iterable[logging.Handler]) -> None:
+    """!
+    @brief Reset a logger and attach the supplied handlers.
+    """
+
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+    for flt in list(logger.filters):
+        logger.removeFilter(flt)
+    for handler in handlers_to_add:
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.propagate = False
+
+
+def setup_logging(
+    root_dir: Path,
+    *,
+    json_to_stdout: bool = False,
+    level: int = logging.INFO,
+) -> Tuple[logging.Logger, logging.Logger]:
+    """!
+    @brief Set up human and machine loggers.
+    @details The function returns a pair of ``logging.Logger`` objects for the
+    human-readable and structured event channels respectively. The directory is
+    created if it does not exist and rotated files are configured for both
+    streams.
+    """
+
+    global _CURRENT_LOG_DIRECTORY
+
+    root_dir.mkdir(parents=True, exist_ok=True)
+    _CURRENT_LOG_DIRECTORY = root_dir
+
+    human_logger = logging.getLogger(HUMAN_LOGGER_NAME)
+    machine_logger = logging.getLogger(MACHINE_LOGGER_NAME)
+
+    human_logger.setLevel(level)
+    machine_logger.setLevel(level)
+
+    human_formatter = logging.Formatter(
+        "%(asctime)s %(levelname)-8s [%(channel)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    machine_formatter = _JsonLineFormatter()
+
+    human_file = handlers.RotatingFileHandler(
+        root_dir / "office-janitor.log",
+        maxBytes=1_048_576,
+        backupCount=5,
+        encoding="utf-8",
+    )
+    machine_file = handlers.RotatingFileHandler(
+        root_dir / "office-janitor.jsonl",
+        maxBytes=1_048_576,
+        backupCount=5,
+        encoding="utf-8",
+    )
+
+    machine_handlers: list[logging.Handler] = [machine_file]
+    if json_to_stdout:
+        machine_handlers.append(logging.StreamHandler(stream=sys.stdout))
+
+    _configure_logger(human_logger, human_formatter, [human_file])
+    _configure_logger(machine_logger, machine_formatter, machine_handlers)
+
+    human_logger.addFilter(_ChannelFilter("human"))
+    machine_logger.addFilter(_ChannelFilter("machine"))
+
+    return human_logger, machine_logger
+
+
+def get_human_logger() -> logging.Logger:
+    """!
+    @brief Retrieve the configured human-readable logger.
+    @details The helper ensures downstream modules share the same formatting and
+    metadata expectations established during :func:`setup_logging`.
+    """
+
+    return logging.getLogger(HUMAN_LOGGER_NAME)
+
+
+def get_machine_logger() -> logging.Logger:
+    """!
+    @brief Retrieve the configured machine/JSON logger.
+    @details Downstream callers can use this helper rather than creating ad-hoc
+    structured logging configuration.
+    """
+
+    return logging.getLogger(MACHINE_LOGGER_NAME)
+
+
+def get_log_directory() -> Path | None:
+    """!
+    @brief Return the most recently configured log directory, if any.
+    """
+
+    return _CURRENT_LOG_DIRECTORY

--- a/src/office_janitor/main.py
+++ b/src/office_janitor/main.py
@@ -122,17 +122,19 @@ def _resolve_log_directory(candidate: Optional[str]) -> pathlib.Path:
 
 def _bootstrap_logging(args: argparse.Namespace) -> tuple[logging.Logger, logging.Logger]:
     """!
-    @brief Initialize human and machine loggers, falling back if unimplemented.
+    @brief Initialize human and machine loggers using :mod:`logging_ext` helpers.
     """
 
     logdir = _resolve_log_directory(getattr(args, "logdir", None))
-    try:
-        return logging_ext.setup_logging(logdir, json_to_stdout=getattr(args, "json", False))
-    except NotImplementedError:
-        logging.basicConfig(level=logging.INFO)
-        human = logging.getLogger("human")
-        machine = logging.getLogger("machine")
-        return human, machine
+    logdir.mkdir(parents=True, exist_ok=True)
+    setattr(args, "logdir", str(logdir))
+    human_logger, machine_logger = logging_ext.setup_logging(
+        logdir,
+        json_to_stdout=getattr(args, "json", False),
+    )
+    setattr(args, "human_logger", human_logger)
+    setattr(args, "machine_logger", machine_logger)
+    return human_logger, machine_logger
 
 
 def main(argv: Optional[Iterable[str]] = None) -> int:

--- a/tests/test_logging_ext.py
+++ b/tests/test_logging_ext.py
@@ -1,0 +1,102 @@
+"""!
+@brief Tests for :mod:`office_janitor.logging_ext`.
+"""
+from __future__ import annotations
+
+import io
+import json
+import logging
+import pathlib
+import sys
+from contextlib import redirect_stdout
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from office_janitor import logging_ext
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging_state() -> None:
+    """!
+    @brief Reset logging between tests to avoid handler leakage.
+    """
+
+    yield
+    logging.shutdown()
+    for name in (logging_ext.HUMAN_LOGGER_NAME, logging_ext.MACHINE_LOGGER_NAME):
+        logger = logging.getLogger(name)
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()
+        for flt in list(logger.filters):
+            logger.removeFilter(flt)
+
+
+def _flush(logger: logging.Logger) -> None:
+    """!
+    @brief Flush all handlers for deterministic file writes.
+    """
+
+    for handler in logger.handlers:
+        handler.flush()
+
+
+def test_setup_logging_creates_files_and_formats(tmp_path) -> None:
+    """!
+    @brief Ensure setup creates log files and applies expected formatting.
+    """
+
+    human_logger, machine_logger = logging_ext.setup_logging(tmp_path)
+    human_logger.info("hello world")
+    machine_logger.info("startup", extra={"event": "startup", "data": {"mode": "auto"}})
+    _flush(human_logger)
+    _flush(machine_logger)
+
+    human_log = tmp_path / "office-janitor.log"
+    machine_log = tmp_path / "office-janitor.jsonl"
+
+    assert human_log.exists()
+    assert machine_log.exists()
+
+    human_text = human_log.read_text(encoding="utf-8")
+    assert "hello world" in human_text
+    assert "[human]" in human_text
+
+    machine_line = machine_log.read_text(encoding="utf-8").strip().splitlines()[0]
+    payload = json.loads(machine_line)
+    assert payload["event"] == "startup"
+    assert payload["channel"] == "machine"
+    assert payload["data"] == {"mode": "auto"}
+
+
+def test_json_stdout_mirror(tmp_path) -> None:
+    """!
+    @brief Verify machine logs can be mirrored to stdout when requested.
+    """
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        _, machine_logger = logging_ext.setup_logging(tmp_path, json_to_stdout=True)
+        machine_logger.warning("mirror", extra={"event": "mirror"})
+        _flush(machine_logger)
+
+    output_lines = [line for line in buffer.getvalue().splitlines() if line.strip()]
+    assert output_lines, "Expected JSONL output on stdout"
+    parsed = json.loads(output_lines[-1])
+    assert parsed["event"] == "mirror"
+    assert parsed["channel"] == "machine"
+
+
+def test_logger_helpers_return_configured_instances(tmp_path) -> None:
+    """!
+    @brief Helper accessors should mirror the configured loggers.
+    """
+
+    human_logger, machine_logger = logging_ext.setup_logging(tmp_path)
+    assert logging_ext.get_human_logger() is human_logger
+    assert logging_ext.get_machine_logger() is machine_logger


### PR DESCRIPTION
## Summary
- implement dual-channel logging with rotating human logs and JSONL telemetry mirroring
- expose helpers and CLI wiring so subsystems share the configured log directory and loggers
- add pytest coverage to validate log file creation, formatting, and stdout mirroring

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fbad0f1e788325b5a701730e63d649