### PR TITLE
Implement Office detection helpers and tests

### DIFF
--- a/src/office_janitor/constants.py
+++ b/src/office_janitor/constants.py
@@ -6,6 +6,33 @@ specification.
 """
 from __future__ import annotations
 
+from typing import Dict, Tuple
+
+try:  # pragma: no cover - Windows registry handles are optional on test hosts.
+    import winreg
+except ImportError:  # pragma: no cover - test scaffolding supplies substitutes.
+    winreg = None  # type: ignore[assignment]
+
+
+if winreg is not None:  # pragma: no branch - deterministic assignments.
+    HKLM = winreg.HKEY_LOCAL_MACHINE
+    HKCU = winreg.HKEY_CURRENT_USER
+    HKCR = winreg.HKEY_CLASSES_ROOT
+    HKU = winreg.HKEY_USERS
+else:  # pragma: no cover - exercised implicitly in non-Windows CI.
+    HKLM = 0x80000002
+    HKCU = 0x80000001
+    HKCR = 0x80000000
+    HKU = 0x80000003
+
+
+REGISTRY_ROOTS: Dict[str, int] = {
+    "HKLM": HKLM,
+    "HKCU": HKCU,
+    "HKCR": HKCR,
+    "HKU": HKU,
+}
+
 SUPPORTED_VERSIONS = (
     "2003",
     "2007",
@@ -26,3 +53,139 @@ DEFAULT_OFFICE_PROCESSES = (
     "visio.exe",
     "powerpnt.exe",
 )
+
+MSI_UNINSTALL_ROOTS: Tuple[Tuple[int, str], ...] = (
+    (HKLM, r"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall"),
+    (HKLM, r"SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall"),
+)
+
+MSI_PRODUCT_CODES: Dict[str, Dict[str, str]] = {
+    "{90150000-0011-0000-0000-0000000FF1CE}": {
+        "release": "2013",
+        "generation": "Office15",
+        "edition": "Professional Plus",
+        "architecture": "x86",
+        "install_path": r"C:\\Program Files (x86)\\Microsoft Office\\Office15",
+    },
+    "{91160000-0011-0000-0000-0000000FF1CE}": {
+        "release": "2016",
+        "generation": "Office16",
+        "edition": "Professional Plus",
+        "architecture": "x64",
+        "install_path": r"C:\\Program Files\\Microsoft Office\\Office16",
+    },
+    "{91190000-0011-0000-0000-0000000FF1CE}": {
+        "release": "2019",
+        "generation": "Office17",
+        "edition": "Professional Plus",
+        "architecture": "x64",
+        "install_path": r"C:\\Program Files\\Microsoft Office\\Office17",
+    },
+    "{91140000-0011-0000-0000-0000000FF1CE}": {
+        "release": "2010",
+        "generation": "Office14",
+        "edition": "Professional Plus",
+        "architecture": "x86",
+        "install_path": r"C:\\Program Files (x86)\\Microsoft Office\\Office14",
+    },
+}
+
+C2R_CONFIGURATION_KEYS: Tuple[Tuple[int, str], ...] = (
+    (HKLM, r"SOFTWARE\\Microsoft\\Office\\ClickToRun\\Configuration"),
+    (HKCU, r"SOFTWARE\\Microsoft\\Office\\ClickToRun\\Configuration"),
+)
+
+C2R_SUBSCRIPTION_ROOTS: Tuple[Tuple[int, str], ...] = (
+    (HKLM, r"SOFTWARE\\Microsoft\\Office\\ClickToRun\\Configuration\\Subscriptions"),
+    (HKCU, r"SOFTWARE\\Microsoft\\Office\\ClickToRun\\Configuration\\Subscriptions"),
+)
+
+C2R_COM_REGISTRY_PATHS: Tuple[Tuple[int, str], ...] = (
+    (HKLM, r"SOFTWARE\\Microsoft\\Office\\ClickToRun\\COM Compatibility\\Applications"),
+    (HKCU, r"SOFTWARE\\Microsoft\\Office\\ClickToRun\\COM Compatibility\\Applications"),
+)
+
+C2R_PLATFORM_ALIASES: Dict[str, str] = {
+    "x86": "x86",
+    "x64": "x64",
+    "arm64": "ARM64",
+    "neutral": "neutral",
+}
+
+C2R_CHANNELS: Dict[str, str] = {
+    "Production::CC": "Current Channel",
+    "Production::MEC": "Monthly Enterprise Channel",
+    "Production::SAEC": "Semi-Annual Enterprise Channel",
+    "Production::Beta": "Beta Channel",
+    "Production::InsiderFast": "Insider Fast",
+    "http://officecdn.microsoft.com/pr/492350f6-3a04-4b59-8b34-4c547755c2a0": "Current Channel",
+    "http://officecdn.microsoft.com/pr/55336b82-a18d-4dd6-b5f6-9e5095c314a6": "Monthly Enterprise Channel",
+    "http://officecdn.microsoft.com/pr/7ffbc6bf-bc32-4f92-8982-f9dd17fd3114": "Semi-Annual Enterprise Channel",
+}
+
+KNOWN_SCHEDULED_TASKS = (
+    r"Microsoft\\Office\\OfficeTelemetryAgentFallBack",
+    r"Microsoft\\Office\\OfficeTelemetryAgentLogOn",
+    r"Microsoft\\Office\\OfficeBackgroundTaskHandlerLogon",
+    r"Microsoft\\Office\\OfficeBackgroundTaskHandlerRegistration",
+)
+
+KNOWN_SERVICES = (
+    "ClickToRunSvc",
+    "OfficeSvc",
+    "ose",
+    "ose64",
+)
+
+INSTALL_ROOT_TEMPLATES = (
+    {
+        "label": "c2r_root_x86",
+        "path": r"C:\\Program Files (x86)\\Microsoft Office\\root",
+        "architecture": "x86",
+        "release": "C2R",
+    },
+    {
+        "label": "c2r_root_x64",
+        "path": r"C:\\Program Files\\Microsoft Office\\root",
+        "architecture": "x64",
+        "release": "C2R",
+    },
+    {
+        "label": "office16_x86",
+        "path": r"C:\\Program Files (x86)\\Microsoft Office\\Office16",
+        "architecture": "x86",
+        "release": "2016",
+    },
+    {
+        "label": "office16_x64",
+        "path": r"C:\\Program Files\\Microsoft Office\\Office16",
+        "architecture": "x64",
+        "release": "2016",
+    },
+    {
+        "label": "office15_x86",
+        "path": r"C:\\Program Files (x86)\\Microsoft Office\\Office15",
+        "architecture": "x86",
+        "release": "2013",
+    },
+)
+
+__all__ = [
+    "C2R_CHANNELS",
+    "C2R_COM_REGISTRY_PATHS",
+    "C2R_CONFIGURATION_KEYS",
+    "C2R_PLATFORM_ALIASES",
+    "C2R_SUBSCRIPTION_ROOTS",
+    "DEFAULT_OFFICE_PROCESSES",
+    "HKCR",
+    "HKCU",
+    "HKLM",
+    "HKU",
+    "INSTALL_ROOT_TEMPLATES",
+    "KNOWN_SCHEDULED_TASKS",
+    "KNOWN_SERVICES",
+    "MSI_PRODUCT_CODES",
+    "MSI_UNINSTALL_ROOTS",
+    "REGISTRY_ROOTS",
+    "SUPPORTED_VERSIONS",
+]

--- a/src/office_janitor/detect.py
+++ b/src/office_janitor/detect.py
@@ -6,7 +6,20 @@ deployments as described in the project specification.
 """
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict, List
+
+from . import constants, registry_tools
+
+
+def _friendly_channel(raw_channel: str | None) -> str:
+    """!
+    @brief Resolve a friendly channel name for Click-to-Run metadata.
+    """
+
+    if not raw_channel:
+        return "unknown"
+    return constants.C2R_CHANNELS.get(raw_channel, raw_channel)
 
 
 def detect_msi_installations() -> List[Dict[str, str]]:
@@ -14,20 +27,143 @@ def detect_msi_installations() -> List[Dict[str, str]]:
     @brief Inspect the registry and return metadata for MSI-based Office installs.
     """
 
-    raise NotImplementedError
+    installations: List[Dict[str, str]] = []
+    seen_codes: set[str] = set()
+
+    for root, base_key in constants.MSI_UNINSTALL_ROOTS:
+        try:
+            subkeys = list(registry_tools.iter_subkeys(root, base_key))
+        except (FileNotFoundError, OSError):
+            continue
+
+        for subkey in subkeys:
+            key_path = f"{base_key}\\{subkey}"
+            entry = registry_tools.read_values(root, key_path)
+            if not entry:
+                continue
+            product_code = entry.get("ProductCode") or subkey
+            metadata = constants.MSI_PRODUCT_CODES.get(product_code)
+            if not metadata or product_code in seen_codes:
+                continue
+
+            installation: Dict[str, str] = {
+                "product_code": product_code,
+                "release": metadata.get("release", "unknown"),
+                "generation": metadata.get("generation", "unknown"),
+                "edition": metadata.get("edition", entry.get("DisplayName", "")),
+                "display_name": entry.get("DisplayName", metadata.get("edition", "")),
+                "display_version": entry.get("DisplayVersion", ""),
+                "architecture": metadata.get("architecture", "unknown"),
+                "channel": "MSI",
+                "uninstall_key": key_path,
+                "source": f"{registry_tools.hive_name(root)}\\{key_path}",
+            }
+            install_root = metadata.get("install_path")
+            if install_root:
+                installation["install_path"] = install_root
+
+            installations.append(installation)
+            seen_codes.add(product_code)
+
+    return installations
 
 
-def detect_c2r_installations() -> List[Dict[str, str]]:
+def detect_c2r_installations() -> List[Dict[str, object]]:
     """!
     @brief Probe Click-to-Run configuration to describe installed suites.
     """
 
-    raise NotImplementedError
+    installations: List[Dict[str, object]] = []
+
+    for root, config_path in constants.C2R_CONFIGURATION_KEYS:
+        config_values = registry_tools.read_values(root, config_path)
+        if not config_values:
+            continue
+
+        raw_release_ids = str(config_values.get("ProductReleaseIds", "")).split(",")
+        release_ids = [rid.strip() for rid in raw_release_ids if rid.strip()]
+        if not release_ids:
+            continue
+
+        platform = str(config_values.get("Platform") or config_values.get("PlatformId") or "").lower()
+        architecture = constants.C2R_PLATFORM_ALIASES.get(platform, platform or "unknown")
+        version = (
+            config_values.get("VersionToReport")
+            or config_values.get("ClientVersionToReport")
+            or config_values.get("ProductVersion")
+            or ""
+        )
+        channel_identifier = (
+            config_values.get("UpdateChannel")
+            or config_values.get("ChannelId")
+            or config_values.get("CDNBaseUrl")
+        )
+        channel = _friendly_channel(str(channel_identifier) if channel_identifier else None)
+
+        subscriptions: List[Dict[str, str]] = []
+        for sub_root, sub_path in constants.C2R_SUBSCRIPTION_ROOTS:
+            try:
+                subkeys = list(registry_tools.iter_subkeys(sub_root, sub_path))
+            except (FileNotFoundError, OSError):
+                continue
+            for subkey in subkeys:
+                values = registry_tools.read_values(sub_root, f"{sub_path}\\{subkey}")
+                raw_channel = values.get("ChannelId") or values.get("UpdateChannel")
+                subscriptions.append(
+                    {
+                        "product_id": subkey,
+                        "channel": _friendly_channel(str(raw_channel) if raw_channel else None),
+                    }
+                )
+
+        com_entries: List[str] = []
+        for com_root, com_path in constants.C2R_COM_REGISTRY_PATHS:
+            try:
+                com_entries.extend(list(registry_tools.iter_subkeys(com_root, com_path)))
+            except (FileNotFoundError, OSError):
+                continue
+
+        installations.append(
+            {
+                "release_ids": release_ids,
+                "channel": channel,
+                "architecture": architecture,
+                "version": str(version),
+                "com_registration_count": len(com_entries),
+                "subscriptions": subscriptions,
+                "source": f"{registry_tools.hive_name(root)}\\{config_path}",
+            }
+        )
+
+    return installations
 
 
-def gather_office_inventory() -> Dict[str, List[Dict[str, str]]]:
+def gather_office_inventory() -> Dict[str, List[Dict[str, object]]]:
     """!
     @brief Aggregate MSI, C2R, and ancillary signals into an inventory payload.
     """
 
-    raise NotImplementedError
+    inventory: Dict[str, List[Dict[str, object]]] = {
+        "msi": detect_msi_installations(),
+        "c2r": detect_c2r_installations(),
+        "filesystem": [],
+    }
+
+    for template in constants.INSTALL_ROOT_TEMPLATES:
+        candidate = Path(template["path"])
+        try:
+            exists = candidate.exists()
+        except OSError:
+            exists = False
+        if not exists:
+            continue
+        inventory["filesystem"].append(
+            {
+                "path": str(candidate),
+                "architecture": template.get("architecture", "unknown"),
+                "release": template.get("release", ""),
+                "label": template.get("label", ""),
+            }
+        )
+
+    return inventory

--- a/src/office_janitor/registry_tools.py
+++ b/src/office_janitor/registry_tools.py
@@ -6,15 +6,52 @@ the specification.
 """
 from __future__ import annotations
 
-from typing import Iterable
+import shutil
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, Tuple
+
+try:  # pragma: no cover - exercised through mocks on non-Windows platforms.
+    import winreg
+except ImportError:  # pragma: no cover - handled gracefully during tests.
+    winreg = None  # type: ignore[assignment]
+
+
+def _ensure_winreg() -> None:
+    """!  
+    @brief Raise an informative error when ``winreg`` is unavailable.
+    """
+
+    if winreg is None:  # pragma: no cover - simplifies non-Windows test runs.
+        raise FileNotFoundError("Windows registry APIs are unavailable on this platform")
 
 
 def export_keys(keys: Iterable[str], destination: str) -> None:
     """!
     @brief Export the provided registry keys to ``.reg`` files in ``destination``.
+    @details On non-Windows systems the exports become placeholder files so unit
+    tests and dry-run flows can still verify orchestration logic without access
+    to the native ``reg.exe`` utility.
     """
 
-    raise NotImplementedError
+    dest_path = Path(destination)
+    dest_path.mkdir(parents=True, exist_ok=True)
+    reg_executable = shutil.which("reg")
+
+    for key in keys:
+        safe_name = key.replace("\\", "_").replace("/", "_")
+        export_path = dest_path / f"{safe_name}.reg"
+        if reg_executable:
+            subprocess.run(
+                [reg_executable, "export", key, str(export_path), "/y"],
+                check=True,
+            )
+        else:  # pragma: no cover - depends on environment availability.
+            export_path.write_text(
+                f"; Placeholder export for {key}\n",
+                encoding="utf-8",
+            )
 
 
 def delete_keys(keys: Iterable[str], *, dry_run: bool = False) -> None:
@@ -22,4 +59,124 @@ def delete_keys(keys: Iterable[str], *, dry_run: bool = False) -> None:
     @brief Remove registry keys while respecting dry-run safeguards.
     """
 
-    raise NotImplementedError
+    reg_executable = shutil.which("reg")
+
+    for key in keys:
+        if dry_run or not reg_executable:
+            continue
+        subprocess.run([reg_executable, "delete", key, "/f"], check=True)
+
+
+@contextmanager
+def open_key(root: int, path: str, access: int | None = None) -> Iterator[Any]:
+    """!
+    @brief Context manager that mirrors ``winreg.OpenKey`` while ensuring
+    handles are closed correctly.
+    """
+
+    _ensure_winreg()
+    access_mask = access if access is not None else winreg.KEY_READ  # type: ignore[union-attr]
+    handle = winreg.OpenKey(root, path, 0, access_mask)  # type: ignore[union-attr]
+    try:
+        yield handle
+    finally:
+        winreg.CloseKey(handle)  # type: ignore[union-attr]
+
+
+def iter_subkeys(root: int, path: str) -> Iterator[str]:
+    """!
+    @brief Yield subkey names for ``root``/``path``.
+    """
+
+    _ensure_winreg()
+    with open_key(root, path) as handle:
+        subkey_count, _, _ = winreg.QueryInfoKey(handle)  # type: ignore[union-attr]
+        for index in range(subkey_count):
+            yield winreg.EnumKey(handle, index)  # type: ignore[union-attr]
+
+
+def iter_values(root: int, path: str) -> Iterator[Tuple[str, Any]]:
+    """!
+    @brief Yield value name/value pairs for ``root``/``path``.
+    """
+
+    _ensure_winreg()
+    with open_key(root, path) as handle:
+        _, value_count, _ = winreg.QueryInfoKey(handle)  # type: ignore[union-attr]
+        for index in range(value_count):
+            name, value, _ = winreg.EnumValue(handle, index)  # type: ignore[union-attr]
+            yield name, value
+
+
+def read_values(root: int, path: str) -> Dict[str, Any]:
+    """!
+    @brief Read all values beneath ``root``/``path`` into a dictionary.
+    """
+
+    data: Dict[str, Any] = {}
+    try:
+        for name, value in iter_values(root, path):
+            data[name] = value
+    except FileNotFoundError:
+        return {}
+    except OSError:
+        return {}
+    return data
+
+
+def get_value(root: int, path: str, value_name: str, default: Any | None = None) -> Any | None:
+    """!
+    @brief Read ``value_name`` beneath ``root``/``path``.
+    """
+
+    try:
+        _ensure_winreg()
+        with open_key(root, path) as handle:
+            value, _ = winreg.QueryValueEx(handle, value_name)  # type: ignore[union-attr]
+            return value
+    except FileNotFoundError:
+        return default
+    except OSError:
+        return default
+
+
+def key_exists(root: int, path: str) -> bool:
+    """!
+    @brief Determine whether the given key exists.
+    """
+
+    try:
+        _ensure_winreg()
+        with open_key(root, path):
+            return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
+
+
+def hive_name(root: int) -> str:
+    """!
+    @brief Provide a friendly identifier for a registry hive.
+    """
+
+    mapping = {
+        getattr(winreg, "HKEY_LOCAL_MACHINE", 0): "HKLM",  # type: ignore[union-attr]
+        getattr(winreg, "HKEY_CURRENT_USER", 0): "HKCU",  # type: ignore[union-attr]
+        getattr(winreg, "HKEY_USERS", 0): "HKU",  # type: ignore[union-attr]
+        getattr(winreg, "HKEY_CLASSES_ROOT", 0): "HKCR",  # type: ignore[union-attr]
+    }
+    return mapping.get(root, hex(root))
+
+
+__all__ = [
+    "delete_keys",
+    "export_keys",
+    "get_value",
+    "hive_name",
+    "iter_subkeys",
+    "iter_values",
+    "key_exists",
+    "open_key",
+    "read_values",
+]

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,22 +1,185 @@
 """!
 @brief Detection scaffolding tests.
-@details Placeholder coverage for registry probing and detection heuristics defined in the spec.
+@details Coverage for registry probing and detection heuristics defined in the spec.
 """
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, List
 
 import pytest
 
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
 
-@pytest.mark.skip(reason="Placeholder for detection registry probing scenarios.")
+from office_janitor import constants, detect
+
+
 class TestRegistryDetectionScenarios:
     """!
     @brief Registry probing detection scenarios.
-    @details Will validate discovery of Office installations across registry hives, install roots, and
-    release channels once detection logic is implemented.
+    @details Validates discovery of Office installations across registry hives, install roots, and
+    release channels.
     """
 
-    def test_registry_probe_placeholder(self) -> None:
+    def test_msi_detection_aggregates_known_product_codes(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """!
-        @brief Placeholder detection test.
-        @details Ensures discovery logic handles multiple Office versions and architecture combinations.
+        @brief Validate MSI discovery for multiple generations and architectures.
         """
-        pytest.skip("Placeholder for detection registry probing scenarios.")
+
+        base_uninstall = constants.MSI_UNINSTALL_ROOTS[0][1]
+        wow_uninstall = constants.MSI_UNINSTALL_ROOTS[1][1]
+
+        def fake_iter_subkeys(root: int, path: str) -> List[str]:
+            if path == base_uninstall:
+                return [
+                    "{91160000-0011-0000-0000-0000000FF1CE}",
+                    "{91190000-0011-0000-0000-0000000FF1CE}",
+                    "{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}",
+                ]
+            if path == wow_uninstall:
+                return [
+                    "{90150000-0011-0000-0000-0000000FF1CE}",
+                    "{91140000-0011-0000-0000-0000000FF1CE}",
+                ]
+            return []
+
+        key_values: Dict[str, Dict[str, str]] = {
+            f"{base_uninstall}\\{{91160000-0011-0000-0000-0000000FF1CE}}": {
+                "ProductCode": "{91160000-0011-0000-0000-0000000FF1CE}",
+                "DisplayName": "Microsoft Office Professional Plus 2016",
+                "DisplayVersion": "16.0.4266.1003",
+            },
+            f"{base_uninstall}\\{{91190000-0011-0000-0000-0000000FF1CE}}": {
+                "ProductCode": "{91190000-0011-0000-0000-0000000FF1CE}",
+                "DisplayName": "Microsoft Office Professional Plus 2019",
+                "DisplayVersion": "16.0.10396.20017",
+            },
+            f"{base_uninstall}\\{{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}}": {
+                "ProductCode": "{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}",
+                "DisplayName": "Contoso Helper",
+                "DisplayVersion": "1.0.0",
+            },
+            f"{wow_uninstall}\\{{90150000-0011-0000-0000-0000000FF1CE}}": {
+                "ProductCode": "{90150000-0011-0000-0000-0000000FF1CE}",
+                "DisplayName": "Microsoft Office Professional Plus 2013",
+                "DisplayVersion": "15.0.4569.1506",
+            },
+            f"{wow_uninstall}\\{{91140000-0011-0000-0000-0000000FF1CE}}": {
+                "ProductCode": "{91140000-0011-0000-0000-0000000FF1CE}",
+                "DisplayName": "Microsoft Office Professional Plus 2010",
+                "DisplayVersion": "14.0.7268.5000",
+            },
+        }
+
+        def fake_read_values(root: int, path: str) -> Dict[str, str]:
+            return key_values.get(path, {})
+
+        monkeypatch.setattr(detect.registry_tools, "iter_subkeys", fake_iter_subkeys)
+        monkeypatch.setattr(detect.registry_tools, "read_values", fake_read_values)
+
+        installations = detect.detect_msi_installations()
+
+        codes = {entry["product_code"] for entry in installations}
+        assert codes == {
+            "{91160000-0011-0000-0000-0000000FF1CE}",
+            "{91190000-0011-0000-0000-0000000FF1CE}",
+            "{90150000-0011-0000-0000-0000000FF1CE}",
+            "{91140000-0011-0000-0000-0000000FF1CE}",
+        }
+        assert {entry["architecture"] for entry in installations} == {"x64", "x86"}
+        assert all(entry["channel"] == "MSI" for entry in installations)
+
+    def test_click_to_run_detection_collects_channel_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """!
+        @brief Validate Click-to-Run discovery of channels, subscriptions, and COM registrations.
+        """
+
+        config_root, config_path = constants.C2R_CONFIGURATION_KEYS[0]
+        subscription_path = constants.C2R_SUBSCRIPTION_ROOTS[0][1]
+        com_path = constants.C2R_COM_REGISTRY_PATHS[0][1]
+
+        def fake_read_values(root: int, path: str) -> Dict[str, str]:
+            if path == config_path and root == config_root:
+                return {
+                    "ProductReleaseIds": "O365ProPlusRetail,ProjectProRetail",
+                    "Platform": "x64",
+                    "VersionToReport": "16.0.17029.20108",
+                    "UpdateChannel": "http://officecdn.microsoft.com/pr/55336b82-a18d-4dd6-b5f6-9e5095c314a6",
+                }
+            if path == f"{subscription_path}\\O365ProPlusRetail":
+                return {"ChannelId": "Production::MEC"}
+            if path == f"{subscription_path}\\ProjectProRetail":
+                return {"ChannelId": "Production::CC"}
+            return {}
+
+        def fake_iter_subkeys(root: int, path: str) -> List[str]:
+            if path == subscription_path and root == constants.C2R_SUBSCRIPTION_ROOTS[0][0]:
+                return ["O365ProPlusRetail", "ProjectProRetail"]
+            if path == com_path and root == constants.C2R_COM_REGISTRY_PATHS[0][0]:
+                return ["{1111}", "{2222}", "{3333}"]
+            return []
+
+        monkeypatch.setattr(detect.registry_tools, "read_values", fake_read_values)
+        monkeypatch.setattr(detect.registry_tools, "iter_subkeys", fake_iter_subkeys)
+
+        installations = detect.detect_c2r_installations()
+
+        assert len(installations) == 1
+        record = installations[0]
+        assert record["release_ids"] == ["O365ProPlusRetail", "ProjectProRetail"]
+        assert record["architecture"] == "x64"
+        assert record["channel"] == "Monthly Enterprise Channel"
+        assert record["com_registration_count"] == 3
+        subscription_channels = {sub["channel"] for sub in record["subscriptions"]}
+        assert subscription_channels == {"Monthly Enterprise Channel", "Current Channel"}
+
+    def test_inventory_aggregates_registry_and_filesystem_signals(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """!
+        @brief Validate that the inventory collector merges registry and filesystem hints.
+        """
+
+        monkeypatch.setattr(
+            detect,
+            "detect_msi_installations",
+            lambda: [
+                {
+                    "product_code": "{91160000-0011-0000-0000-0000000FF1CE}",
+                    "architecture": "x64",
+                    "channel": "MSI",
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            detect,
+            "detect_c2r_installations",
+            lambda: [
+                {
+                    "release_ids": ["O365ProPlusRetail"],
+                    "architecture": "x64",
+                    "channel": "Current Channel",
+                }
+            ],
+        )
+
+        valid_paths = {
+            constants.INSTALL_ROOT_TEMPLATES[0]["path"],
+            constants.INSTALL_ROOT_TEMPLATES[2]["path"],
+        }
+
+        def fake_exists(self: Path) -> bool:  # type: ignore[override]
+            return str(self) in valid_paths
+
+        monkeypatch.setattr(detect.Path, "exists", fake_exists, raising=False)
+
+        inventory = detect.gather_office_inventory()
+
+        assert len(inventory["msi"]) == 1
+        assert len(inventory["c2r"]) == 1
+        assert len(inventory["filesystem"]) == 2
+        labels = {entry["label"] for entry in inventory["filesystem"]}
+        assert labels == {"c2r_root_x86", "office16_x86"}


### PR DESCRIPTION
## Summary
- add registry export/delete helpers and winreg wrappers for detection to consume
- extend constants with MSI GUIDs, Click-to-Run registry paths, channels, and filesystem templates
- implement MSI/Click-to-Run detection plus filesystem aggregation with regression tests covering multiple releases

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68fbb5cb0b2c8325bb20605dc7f97ff2