### PR TITLE
Implement planning and safety guardrails

### DIFF
--- a/src/office_janitor/plan.py
+++ b/src/office_janitor/plan.py
@@ -173,18 +173,26 @@ def _normalize_options(options: Mapping[str, object]) -> Dict[str, object]:
 
 
 def _resolve_mode(options: Mapping[str, object]) -> str:
-    explicit = options.get("mode")
-    if isinstance(explicit, str) and explicit:
-        return explicit
-    if options.get("diagnose"):
+    explicit_raw = options.get("mode")
+    explicit = str(explicit_raw).strip() if isinstance(explicit_raw, str) else ""
+    explicit_lower = explicit.lower()
+
+    if options.get("diagnose") or explicit_lower == "diagnose":
         return "diagnose"
-    if options.get("cleanup_only"):
+    if options.get("cleanup_only") or explicit_lower == "cleanup-only":
         return "cleanup-only"
-    if options.get("auto_all"):
+    if options.get("auto_all") or explicit_lower == "auto-all":
         return "auto-all"
+
     target = options.get("target")
     if target:
         return f"target:{target}"
+
+    if explicit_lower.startswith("target:") and len(explicit) > len("target:"):
+        return f"target:{explicit.split(":", 1)[1]}"
+    if explicit:
+        return explicit_lower or explicit
+
     return "interactive"
 
 

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -156,6 +156,37 @@ class TestSafetyPreflight:
         with pytest.raises(ValueError):
             safety.perform_preflight_checks(plan_steps)
 
+    def test_preflight_allows_whitelisted_user_profile_path(self) -> None:
+        """!
+        @brief User profile Office paths remain allowed despite broad blacklist.
+        @details Regression coverage ensuring `%APPDATA%` expansions under
+        `C:\\Users` are accepted even though the user directory is generally
+        blocked.
+        """
+
+        plan_steps = [
+            {
+                "id": "context",
+                "category": "context",
+                "metadata": {
+                    "dry_run": False,
+                    "mode": "cleanup-only",
+                    "target_versions": [],
+                    "unsupported_targets": [],
+                },
+            },
+            {
+                "id": "filesystem-0",
+                "category": "filesystem-cleanup",
+                "metadata": {
+                    "paths": [r"C:\\Users\\Alice\\AppData\\Roaming\\Microsoft\\Office"],
+                    "dry_run": False,
+                },
+            },
+        ]
+
+        safety.perform_preflight_checks(plan_steps)
+
     def test_preflight_detects_dry_run_mismatch(self) -> None:
         """!
         @brief Dry-run flag must propagate consistently.


### PR DESCRIPTION
## Summary
- implement the planner to translate detection inventory and CLI options into ordered uninstall and cleanup steps with dependency metadata
- add safety preflight checks for dry-run consistency, whitelist enforcement, targeted scrub validation, and unsupported version refusal
- create unit tests covering planner mode handling and safety guardrail behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fbc366487c83258eab10a52ed78b81