### PR TITLE
Implement uninstall orchestration and cleanup tests

### DIFF
--- a/src/office_janitor/c2r_uninstall.py
+++ b/src/office_janitor/c2r_uninstall.py
@@ -6,12 +6,162 @@ outlined in the specification.
 """
 from __future__ import annotations
 
-from typing import Mapping
+import subprocess
+import time
+from pathlib import Path
+from typing import Iterable, List, Mapping
+
+from . import logging_ext
+
+DEFAULT_CLIENT_PATHS: tuple[Path, ...] = (
+    Path(r"C:\Program Files\Common Files\Microsoft Shared\ClickToRun\OfficeC2RClient.exe"),
+    Path(r"C:\Program Files (x86)\Common Files\Microsoft Shared\ClickToRun\OfficeC2RClient.exe"),
+)
+"""!
+@brief Common search paths for ``OfficeC2RClient.exe``.
+"""
+
+CLIENT_TIMEOUT = 3600
+"""!
+@brief Timeout (seconds) for Click-to-Run uninstall operations.
+"""
+
+
+def _select_client_path(explicit: str | Path | None) -> Path:
+    """!
+    @brief Choose an ``OfficeC2RClient`` path using configuration hints.
+    """
+
+    if explicit:
+        candidate = Path(explicit)
+        return candidate
+
+    for candidate in DEFAULT_CLIENT_PATHS:
+        if candidate.exists():
+            return candidate
+
+    return DEFAULT_CLIENT_PATHS[0]
+
+
+def _collect_release_ids(raw: Iterable[str] | str | None) -> List[str]:
+    """!
+    @brief Normalise release identifiers into a list for command construction.
+    """
+
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [item.strip() for item in raw.split(",") if item.strip()]
+    return [str(item).strip() for item in raw if str(item).strip()]
 
 
 def uninstall_products(config: Mapping[str, str], *, dry_run: bool = False) -> None:
     """!
     @brief Trigger Click-to-Run uninstall sequences for the supplied configuration.
     """
+    human_logger = logging_ext.get_human_logger()
+    machine_logger = logging_ext.get_machine_logger()
 
-    raise NotImplementedError
+    release_ids = _collect_release_ids(config.get("release_ids") or config.get("products"))
+    if not release_ids:
+        raise ValueError("Click-to-Run uninstall requires at least one release identifier")
+
+    client_path = _select_client_path(config.get("client_path"))
+    additional_args: Iterable[str] | None = config.get("additional_args")  # type: ignore[assignment]
+
+    command: List[str] = [
+        str(client_path),
+        "/update",
+        "user",
+        f"displaylevel=false",
+        "forceappshutdown=true",
+        f"productstoremove={';'.join(release_ids)}",
+        "productstoadd=none",
+    ]
+
+    if additional_args:
+        command.extend(str(arg) for arg in additional_args)
+
+    log_directory = logging_ext.get_log_directory()
+    log_path: Path | None = None
+    if log_directory is not None:
+        joined = "-".join(release_ids)
+        safe = joined.replace("/", "_").replace("\\", "_") or "c2r"
+        log_path = log_directory / f"c2r-{safe}.log"
+        command.extend(["/log", str(log_path)])
+
+    machine_logger.info(
+        "c2r_uninstall_plan",
+        extra={
+            "event": "c2r_uninstall_plan",
+            "release_ids": release_ids,
+            "client_path": str(client_path),
+            "dry_run": bool(dry_run),
+            "log_path": str(log_path) if log_path else None,
+        },
+    )
+
+    if dry_run:
+        human_logger.info("Dry-run: would invoke %s", " ".join(command))
+        return
+
+    start = time.monotonic()
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=CLIENT_TIMEOUT,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        duration = time.monotonic() - start
+        human_logger.error(
+            "OfficeC2RClient timed out after %.1fs for releases %s", duration, ", ".join(release_ids)
+        )
+        machine_logger.error(
+            "c2r_uninstall_timeout",
+            extra={
+                "event": "c2r_uninstall_timeout",
+                "release_ids": release_ids,
+                "duration": duration,
+                "stdout": exc.stdout,
+                "stderr": exc.stderr,
+            },
+        )
+        raise RuntimeError("Click-to-Run uninstall timed out") from exc
+
+    duration = time.monotonic() - start
+    if result.returncode != 0:
+        human_logger.error(
+            "OfficeC2RClient failed with exit code %s for releases %s",
+            result.returncode,
+            ", ".join(release_ids),
+        )
+        machine_logger.error(
+            "c2r_uninstall_failure",
+            extra={
+                "event": "c2r_uninstall_failure",
+                "release_ids": release_ids,
+                "return_code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "duration": duration,
+            },
+        )
+        raise RuntimeError("Click-to-Run uninstall failed")
+
+    human_logger.info(
+        "OfficeC2RClient removed releases %s in %.1f seconds.", ", ".join(release_ids), duration
+    )
+    machine_logger.info(
+        "c2r_uninstall_success",
+        extra={
+            "event": "c2r_uninstall_success",
+            "release_ids": release_ids,
+            "return_code": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "duration": duration,
+        },
+    )

--- a/src/office_janitor/licensing.py
+++ b/src/office_janitor/licensing.py
@@ -6,12 +6,193 @@ specification's safety constraints.
 """
 from __future__ import annotations
 
-from typing import Mapping
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from . import fs_tools, logging_ext
+
+PS_TEMPLATE = r"""
+function UninstallLicenses($DllPath) {
+  $TB = [AppDomain]::CurrentDomain.DefineDynamicAssembly(4,1).DefineDynamicModule(2).DefineType(0)
+  [void]$TB.DefinePInvokeMethod('SLOpen', $DllPath, 22, 1, [int], @([IntPtr].MakeByRefType()), 1, 3)
+  [void]$TB.DefinePInvokeMethod('SLGetSLIDList', $DllPath, 22, 1, [int], @([IntPtr],[int],[Guid].MakeByRefType(),[int],[int].MakeByRefType(),[IntPtr].MakeByRefType()), 1, 3).SetImplementationFlags(128)
+  [void]$TB.DefinePInvokeMethod('SLUninstallLicense', $DllPath, 22, 1, [int], @([IntPtr],[IntPtr]), 1, 3)
+  $SPPC = $TB.CreateType(); $Handle = 0; [void]$SPPC::SLOpen([ref]$Handle)
+  $pnReturnIds = 0; $ppReturnIds = 0
+  if (!$SPPC::SLGetSLIDList($Handle, 0, [ref][Guid]'0ff1ce15-0000-0000-0000-000000000000', 6, [ref]$pnReturnIds, [ref]$ppReturnIds)) {
+    foreach ($i in 0..($pnReturnIds - 1)) { [void]$SPPC::SLUninstallLicense($Handle, [Int64]$ppReturnIds + ($i*16)) }
+  }
+}
+UninstallLicenses('sppc.dll')
+"""
+"""!
+@brief PowerShell script used to purge SPP licenses.
+"""
+
+DEFAULT_OSPP_COMMAND = (
+    "cscript.exe",
+    "//NoLogo",
+    r"C:\\Program Files\\Microsoft Office\\Office16\\ospp.vbs",
+    "/unpkey:all",
+)
+"""!
+@brief Default command tuple used to remove OSPP keys.
+"""
+
+DEFAULT_LICENSE_PATHS: tuple[Path, ...] = (
+    Path(r"C:\\ProgramData\\Microsoft\\OfficeSoftwareProtectionPlatform"),
+    Path(r"C:\\ProgramData\\Microsoft\\Office"),
+)
+"""!
+@brief Common filesystem locations for Office licensing caches.
+"""
+
+
+def _write_powershell_script(content: str) -> Path:
+    """!
+    @brief Persist a PowerShell script to disk for invocation.
+    """
+
+    with tempfile.NamedTemporaryFile("w", suffix=".ps1", delete=False, encoding="utf-8") as handle:
+        handle.write(content)
+        return Path(handle.name)
+
+
+def _expand_paths(raw: Iterable[object] | object | None) -> list[Path]:
+    """!
+    @brief Normalise optional path hints into :class:`Path` objects.
+    """
+
+    if raw is None:
+        return []
+    if isinstance(raw, (str, Path)):
+        candidates = [raw]
+    else:
+        candidates = list(raw)
+    paths: list[Path] = []
+    for candidate in candidates:
+        path = Path(candidate)
+        if path not in paths:
+            paths.append(path)
+    return paths
 
 
 def cleanup_licenses(options: Mapping[str, object]) -> None:
     """!
     @brief Remove activation artifacts based on the requested cleanup options.
     """
+    human_logger = logging_ext.get_human_logger()
+    machine_logger = logging_ext.get_machine_logger()
 
-    raise NotImplementedError
+    dry_run = bool(options.get("dry_run", False))
+    include_spp = options.get("remove_spp", True) not in {False, "false", "0"}
+    include_ospp = options.get("remove_ospp", True) not in {False, "false", "0"}
+    extra_paths = _expand_paths(options.get("paths"))
+    if not extra_paths:
+        extra_paths = list(DEFAULT_LICENSE_PATHS)
+
+    machine_logger.info(
+        "licensing_plan",
+        extra={
+            "event": "licensing_plan",
+            "dry_run": dry_run,
+            "remove_spp": include_spp,
+            "remove_ospp": include_ospp,
+            "paths": [str(path) for path in extra_paths],
+        },
+    )
+
+    if include_spp:
+        script_path: Path | None = None
+        try:
+            script_path = _write_powershell_script(PS_TEMPLATE)
+            command = (
+                "powershell.exe",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(script_path),
+            )
+            if dry_run:
+                human_logger.info("Dry-run: would execute SPP cleanup via %s", " ".join(command))
+            else:
+                human_logger.info("Removing SPP licenses via PowerShell script %s", script_path)
+                result = subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    timeout=300,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    human_logger.error(
+                        "SPP cleanup failed with exit code %s", result.returncode
+                    )
+                    machine_logger.error(
+                        "licensing_spp_failure",
+                        extra={
+                            "event": "licensing_spp_failure",
+                            "return_code": result.returncode,
+                            "stdout": result.stdout,
+                            "stderr": result.stderr,
+                        },
+                    )
+                    raise RuntimeError("SPP license removal failed")
+                machine_logger.info(
+                    "licensing_spp_success",
+                    extra={
+                        "event": "licensing_spp_success",
+                        "stdout": result.stdout,
+                        "stderr": result.stderr,
+                    },
+                )
+        finally:
+            if script_path is not None:
+                try:
+                    script_path.unlink(missing_ok=True)  # type: ignore[arg-type]
+                except OSError:
+                    pass
+
+    if include_ospp:
+        command = options.get("ospp_command", DEFAULT_OSPP_COMMAND)
+        if isinstance(command, (str, Path)):
+            command = (str(command),)
+        command_list = [str(part) for part in command]
+        if dry_run:
+            human_logger.info("Dry-run: would execute OSPP cleanup via %s", " ".join(command_list))
+        else:
+            human_logger.info("Removing OSPP keys via %s", command_list[0])
+            result = subprocess.run(
+                command_list,
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=False,
+            )
+            if result.returncode != 0:
+                human_logger.error("OSPP cleanup failed with exit code %s", result.returncode)
+                machine_logger.error(
+                    "licensing_ospp_failure",
+                    extra={
+                        "event": "licensing_ospp_failure",
+                        "return_code": result.returncode,
+                        "stdout": result.stdout,
+                        "stderr": result.stderr,
+                    },
+                )
+                raise RuntimeError("OSPP license removal failed")
+            machine_logger.info(
+                "licensing_ospp_success",
+                extra={
+                    "event": "licensing_ospp_success",
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                },
+            )
+
+    if extra_paths:
+        human_logger.info("Cleaning licensing cache directories: %s", ", ".join(map(str, extra_paths)))
+        fs_tools.remove_paths(extra_paths, dry_run=dry_run)

--- a/src/office_janitor/msi_uninstall.py
+++ b/src/office_janitor/msi_uninstall.py
@@ -6,12 +6,145 @@ specification.
 """
 from __future__ import annotations
 
-from typing import Iterable
+import subprocess
+import time
+from pathlib import Path
+from typing import Iterable, List
+
+from . import logging_ext
+
+MSIEXEC = "msiexec.exe"
+"""!
+@brief Executable used to drive MSI uninstallations.
+"""
+
+MSIEXEC_TIMEOUT = 1800
+"""!
+@brief Default timeout (seconds) for ``msiexec`` executions.
+"""
+
+
+def _sanitise_product_code(product_code: str) -> str:
+    """!
+    @brief Produce a filesystem-safe representation of ``product_code``.
+    @details ``msiexec`` product codes are GUIDs wrapped in braces. The helper
+    strips these braces and collapses whitespace so the value can be used in log
+    filenames without additional quoting.
+    """
+
+    return product_code.strip().strip("{}").replace("-", "").upper() or "unknown"
+
+
+def _log_target_path(directory: Path | None, product_code: str) -> Path | None:
+    """!
+    @brief Resolve the log path for a given product code if logging is enabled.
+    """
+
+    if directory is None:
+        return None
+    safe_code = _sanitise_product_code(product_code)
+    return directory / f"msi-{safe_code}.log"
 
 
 def uninstall_products(product_codes: Iterable[str], *, dry_run: bool = False) -> None:
     """!
     @brief Uninstall the supplied MSI product codes while respecting dry-run semantics.
     """
+    human_logger = logging_ext.get_human_logger()
+    machine_logger = logging_ext.get_machine_logger()
+    log_directory = logging_ext.get_log_directory()
 
-    raise NotImplementedError
+    codes: List[str] = [code for code in (str(code) for code in product_codes) if code.strip()]
+    if not codes:
+        human_logger.info("No MSI product codes supplied for uninstall; skipping.")
+        return
+
+    human_logger.info(
+        "Preparing to uninstall %d MSI product(s). Dry-run: %s", len(codes), bool(dry_run)
+    )
+    failures: List[str] = []
+
+    for product_code in codes:
+        command: List[str] = [MSIEXEC, "/x", product_code, "/qb!", "/norestart"]
+        log_path = _log_target_path(log_directory, product_code)
+        if log_path is not None:
+            command.extend(["/log", str(log_path)])
+
+        machine_logger.info(
+            "msi_uninstall_plan",
+            extra={
+                "event": "msi_uninstall_plan",
+                "product_code": product_code,
+                "dry_run": bool(dry_run),
+                "log_path": str(log_path) if log_path else None,
+            },
+        )
+
+        if dry_run:
+            human_logger.info("Dry-run: would invoke %s", " ".join(command))
+            continue
+
+        human_logger.info("Invoking msiexec for %s", product_code)
+        start = time.monotonic()
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=MSIEXEC_TIMEOUT,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            duration = time.monotonic() - start
+            message = (
+                f"msiexec timed out after {duration:.1f}s for {product_code}:"
+                f" stdout={exc.stdout!r} stderr={exc.stderr!r}"
+            )
+            human_logger.error(message)
+            machine_logger.error(
+                "msi_uninstall_timeout",
+                extra={
+                    "event": "msi_uninstall_timeout",
+                    "product_code": product_code,
+                    "duration": duration,
+                },
+            )
+            failures.append(product_code)
+            continue
+
+        duration = time.monotonic() - start
+        if result.returncode != 0:
+            human_logger.error(
+                "msiexec for %s failed with exit code %s", product_code, result.returncode
+            )
+            machine_logger.error(
+                "msi_uninstall_failure",
+                extra={
+                    "event": "msi_uninstall_failure",
+                    "product_code": product_code,
+                    "return_code": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                    "duration": duration,
+                },
+            )
+            failures.append(product_code)
+            continue
+
+        human_logger.info(
+            "Successfully uninstalled %s via msiexec in %.1f seconds.", product_code, duration
+        )
+        machine_logger.info(
+            "msi_uninstall_success",
+            extra={
+                "event": "msi_uninstall_success",
+                "product_code": product_code,
+                "return_code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "duration": duration,
+            },
+        )
+
+    if failures:
+        raise RuntimeError(f"Failed to uninstall MSI products: {', '.join(failures)}")

--- a/src/office_janitor/processes.py
+++ b/src/office_janitor/processes.py
@@ -6,12 +6,82 @@ specification's safety and retry requirements.
 """
 from __future__ import annotations
 
-from typing import Iterable
+import subprocess
+from typing import Iterable, List
+
+from . import logging_ext
 
 
 def terminate_office_processes(names: Iterable[str], *, timeout: int = 30) -> None:
     """!
     @brief Stop known Office processes before uninstalling.
     """
+    human_logger = logging_ext.get_human_logger()
+    machine_logger = logging_ext.get_machine_logger()
 
-    raise NotImplementedError
+    processes: List[str] = [name for name in (str(name).strip() for name in names) if name]
+    if not processes:
+        human_logger.debug("No Office processes supplied for termination.")
+        return
+
+    human_logger.info("Requesting termination of %d Office processes.", len(processes))
+    for process in processes:
+        command = ["taskkill.exe", "/IM", process, "/F", "/T"]
+        machine_logger.info(
+            "terminate_process_plan",
+            extra={
+                "event": "terminate_process_plan",
+                "process_name": process,
+                "command": command,
+            },
+        )
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except FileNotFoundError:  # pragma: no cover - non-Windows fallback.
+            human_logger.debug("taskkill.exe is unavailable; skipping termination for %s", process)
+            continue
+        except subprocess.TimeoutExpired as exc:
+            human_logger.warning("Timed out attempting to stop %s", process)
+            machine_logger.warning(
+                "terminate_process_timeout",
+                extra={
+                    "event": "terminate_process_timeout",
+                    "process_name": process,
+                    "stdout": exc.stdout,
+                    "stderr": exc.stderr,
+                },
+            )
+            continue
+
+        if result.returncode != 0:
+            human_logger.debug(
+                "taskkill exited with %s for %s: %s", result.returncode, process, result.stderr.strip()
+            )
+            machine_logger.info(
+                "terminate_process_result",
+                extra={
+                    "event": "terminate_process_result",
+                    "process_name": process,
+                    "return_code": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                },
+            )
+        else:
+            human_logger.info("Terminated %s", process)
+            machine_logger.info(
+                "terminate_process_success",
+                extra={
+                    "event": "terminate_process_success",
+                    "process_name": process,
+                    "return_code": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                },
+            )

--- a/src/office_janitor/restore_point.py
+++ b/src/office_janitor/restore_point.py
@@ -5,10 +5,46 @@ providing optional rollback coverage per the specification.
 """
 from __future__ import annotations
 
+import subprocess
+
+from . import logging_ext
+
 
 def create_restore_point(description: str) -> None:
     """!
     @brief Request a system restore point with the supplied description.
     """
+    human_logger = logging_ext.get_human_logger()
 
-    raise NotImplementedError
+    command = [
+        "powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        (
+            "Checkpoint-Computer -Description \"{}\" "
+            "-RestorePointType 'MODIFY_SETTINGS'".format(description.replace("\"", "'"))
+        ),
+    ]
+
+    human_logger.info("Creating system restore point: %s", description)
+
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except FileNotFoundError:  # pragma: no cover - Windows-specific command.
+        human_logger.debug("powershell.exe unavailable; skipping restore point creation")
+        return
+
+    if result.returncode != 0:
+        human_logger.warning(
+            "Restore point creation returned %s: %s",
+            result.returncode,
+            result.stderr.strip(),
+        )

--- a/src/office_janitor/scrub.py
+++ b/src/office_janitor/scrub.py
@@ -8,10 +8,127 @@ from __future__ import annotations
 
 from typing import Iterable, Mapping
 
+from . import (
+    c2r_uninstall,
+    constants,
+    fs_tools,
+    licensing,
+    logging_ext,
+    msi_uninstall,
+    processes,
+    restore_point,
+    tasks_services,
+)
+
 
 def execute_plan(plan: Iterable[Mapping[str, object]], *, dry_run: bool = False) -> None:
     """!
     @brief Run each plan step while respecting dry-run safety requirements.
     """
+    human_logger = logging_ext.get_human_logger()
+    machine_logger = logging_ext.get_machine_logger()
 
-    raise NotImplementedError
+    steps = [dict(step) for step in plan]
+    if not steps:
+        human_logger.info("No plan steps supplied; nothing to execute.")
+        return
+
+    context = next((step for step in steps if step.get("category") == "context"), None)
+    context_metadata = dict(context.get("metadata", {})) if context else {}
+    options = dict(context_metadata.get("options", {})) if context_metadata else {}
+
+    global_dry_run = bool(dry_run or context_metadata.get("dry_run", False))
+
+    machine_logger.info(
+        "scrub_plan_start",
+        extra={
+            "event": "scrub_plan_start",
+            "step_count": len(steps),
+            "dry_run": global_dry_run,
+            "options": options,
+        },
+    )
+
+    if global_dry_run:
+        human_logger.info("Executing plan in dry-run mode; no destructive actions will occur.")
+    else:
+        if options.get("create_restore_point") or options.get("restore_point"):
+            try:
+                restore_point.create_restore_point("Office Janitor pre-cleanup")
+            except Exception as exc:  # pragma: no cover - defensive logging
+                human_logger.warning("Failed to create restore point: %s", exc)
+
+        processes.terminate_office_processes(constants.DEFAULT_OFFICE_PROCESSES)
+        tasks_services.stop_services(constants.KNOWN_SERVICES)
+        tasks_services.disable_tasks(constants.KNOWN_SCHEDULED_TASKS, dry_run=False)
+
+    for step in steps:
+        category = step.get("category", "unknown")
+        metadata = dict(step.get("metadata", {}))
+        step_dry_run = global_dry_run or bool(metadata.get("dry_run", False))
+
+        machine_logger.info(
+            "scrub_step_start",
+            extra={
+                "event": "scrub_step_start",
+                "step_id": step.get("id"),
+                "category": category,
+                "dry_run": step_dry_run,
+            },
+        )
+
+        try:
+            if category == "context":
+                human_logger.info("Context: %s", metadata)
+            elif category == "msi-uninstall":
+                product = metadata.get("product", {})
+                product_code = product.get("product_code") or metadata.get("product_code")
+                if not product_code:
+                    human_logger.warning("Skipping MSI uninstall step without product code: %s", step)
+                else:
+                    msi_uninstall.uninstall_products([str(product_code)], dry_run=step_dry_run)
+            elif category == "c2r-uninstall":
+                installation = metadata.get("installation") or metadata
+                if not installation:
+                    human_logger.warning("Skipping C2R uninstall step without installation metadata")
+                else:
+                    c2r_uninstall.uninstall_products(installation, dry_run=step_dry_run)
+            elif category == "licensing-cleanup":
+                metadata["dry_run"] = step_dry_run
+                licensing.cleanup_licenses(metadata)
+            elif category == "filesystem-cleanup":
+                paths = metadata.get("paths", [])
+                if not paths:
+                    human_logger.info("No filesystem paths supplied; skipping step.")
+                else:
+                    fs_tools.remove_paths(paths, dry_run=step_dry_run)
+            elif category == "registry-cleanup":
+                human_logger.info("Registry cleanup step planned for keys: %s", metadata.get("keys", []))
+            else:
+                human_logger.info("Unhandled plan category %s; skipping.", category)
+        except Exception as exc:
+            machine_logger.error(
+                "scrub_step_failure",
+                extra={
+                    "event": "scrub_step_failure",
+                    "step_id": step.get("id"),
+                    "category": category,
+                    "error": repr(exc),
+                },
+            )
+            raise
+        else:
+            machine_logger.info(
+                "scrub_step_complete",
+                extra={
+                    "event": "scrub_step_complete",
+                    "step_id": step.get("id"),
+                    "category": category,
+                    "dry_run": step_dry_run,
+                },
+            )
+
+    machine_logger.info(
+        "scrub_plan_complete",
+        extra={"event": "scrub_plan_complete", "step_count": len(steps), "dry_run": global_dry_run},
+    )

--- a/src/office_janitor/tasks_services.py
+++ b/src/office_janitor/tasks_services.py
@@ -6,20 +6,154 @@ specification's guidelines.
 """
 from __future__ import annotations
 
-from typing import Iterable
+import subprocess
+from typing import Iterable, List
+
+from . import logging_ext
 
 
 def disable_tasks(task_names: Iterable[str], *, dry_run: bool = False) -> None:
     """!
     @brief Disable or remove scheduled tasks linked to Office.
     """
+    human_logger = logging_ext.get_human_logger()
+    machine_logger = logging_ext.get_machine_logger()
 
-    raise NotImplementedError
+    tasks: List[str] = [name for name in (str(name).strip() for name in task_names) if name]
+    for task in tasks:
+        command = ["schtasks.exe", "/Change", "/TN", task, "/Disable"]
+        machine_logger.info(
+            "task_disable_plan",
+            extra={
+                "event": "task_disable_plan",
+                "task": task,
+                "dry_run": bool(dry_run),
+            },
+        )
+
+        if dry_run:
+            human_logger.info("Dry-run: would disable scheduled task %s", task)
+            continue
+
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except FileNotFoundError:  # pragma: no cover - non-Windows fallback
+            human_logger.debug("schtasks.exe unavailable; cannot disable %s", task)
+            continue
+
+        if result.returncode != 0:
+            human_logger.debug(
+                "schtasks exited with %s for %s: %s", result.returncode, task, result.stderr.strip()
+            )
+            machine_logger.info(
+                "task_disable_result",
+                extra={
+                    "event": "task_disable_result",
+                    "task": task,
+                    "return_code": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                },
+            )
+        else:
+            human_logger.info("Disabled scheduled task %s", task)
+            machine_logger.info(
+                "task_disable_success",
+                extra={
+                    "event": "task_disable_success",
+                    "task": task,
+                    "return_code": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                },
+            )
 
 
 def stop_services(service_names: Iterable[str], *, timeout: int = 30) -> None:
     """!
     @brief Stop service processes before uninstall operations proceed.
     """
+    human_logger = logging_ext.get_human_logger()
+    machine_logger = logging_ext.get_machine_logger()
 
-    raise NotImplementedError
+    services: List[str] = [name for name in (str(name).strip() for name in service_names) if name]
+    for service in services:
+        stop_command = ["sc.exe", "stop", service]
+        disable_command = ["sc.exe", "config", service, "start=", "disabled"]
+        machine_logger.info(
+            "service_stop_plan",
+            extra={"event": "service_stop_plan", "service": service},
+        )
+
+        try:
+            stop_result = subprocess.run(
+                stop_command,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except FileNotFoundError:  # pragma: no cover - non-Windows fallback
+            human_logger.debug("sc.exe unavailable; cannot stop %s", service)
+            continue
+        except subprocess.TimeoutExpired as exc:
+            human_logger.warning("Timed out stopping service %s", service)
+            machine_logger.warning(
+                "service_stop_timeout",
+                extra={
+                    "event": "service_stop_timeout",
+                    "service": service,
+                    "stdout": exc.stdout,
+                    "stderr": exc.stderr,
+                },
+            )
+            continue
+
+        machine_logger.info(
+            "service_stop_result",
+            extra={
+                "event": "service_stop_result",
+                "service": service,
+                "return_code": stop_result.returncode,
+                "stdout": stop_result.stdout,
+                "stderr": stop_result.stderr,
+            },
+        )
+
+        if stop_result.returncode == 0:
+            human_logger.info("Stopped service %s", service)
+        else:
+            human_logger.debug(
+                "Service %s stop returned %s", service, stop_result.returncode
+            )
+
+        disable_result = subprocess.run(
+            disable_command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        machine_logger.info(
+            "service_disable_result",
+            extra={
+                "event": "service_disable_result",
+                "service": service,
+                "return_code": disable_result.returncode,
+                "stdout": disable_result.stdout,
+                "stderr": disable_result.stderr,
+            },
+        )
+
+        if disable_result.returncode == 0:
+            human_logger.info("Configured service %s to be disabled", service)
+        else:
+            human_logger.debug(
+                "Service %s disable returned %s", service, disable_result.returncode
+            )

--- a/tests/test_cleanup_tools.py
+++ b/tests/test_cleanup_tools.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import List
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from office_janitor import fs_tools, licensing, logging_ext, processes, restore_point, tasks_services
+
+
+class _Result:
+    """!
+    @brief Minimal mock of :class:`subprocess.CompletedProcess` used for testing.
+    """
+
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_cleanup_licenses_runs_commands(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Licensing cleanup should run PowerShell, OSPP, and filesystem steps.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    run_calls: List[List[str]] = []
+    removed: List[tuple[List[str], bool]] = []
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append(cmd)
+        return _Result()
+
+    def fake_remove_paths(paths, *, dry_run: bool):
+        removed.append(([str(path) for path in paths], dry_run))
+
+    monkeypatch.setattr(licensing.subprocess, "run", fake_run)
+    monkeypatch.setattr(licensing.fs_tools, "remove_paths", fake_remove_paths)
+
+    licensing.cleanup_licenses({"paths": [tmp_path / "cache"]})
+
+    assert run_calls, "Expected subprocess commands for licensing cleanup"
+    assert run_calls[0][0] == "powershell.exe"
+    assert run_calls[1][0] == "cscript.exe"
+    assert removed == [([str(tmp_path / "cache")], False)]
+
+
+def test_cleanup_licenses_dry_run(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Dry-run should avoid invoking external commands.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    called = False
+
+    def fake_run(cmd, **kwargs):
+        nonlocal called
+        called = True
+        return _Result()
+
+    def fake_remove_paths(paths, *, dry_run: bool):
+        assert dry_run is True
+
+    monkeypatch.setattr(licensing.subprocess, "run", fake_run)
+    monkeypatch.setattr(licensing.fs_tools, "remove_paths", fake_remove_paths)
+
+    licensing.cleanup_licenses({"dry_run": True, "paths": [tmp_path / "cache"]})
+
+    assert not called
+
+
+def test_remove_paths_deletes_entries(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Filesystem helper should remove files and directories.
+    """
+
+    deleted = tmp_path / "obsolete"
+    deleted.mkdir()
+    (deleted / "inner.txt").write_text("data", encoding="utf-8")
+    file_entry = tmp_path / "file.txt"
+    file_entry.write_text("payload", encoding="utf-8")
+
+    calls: List[pathlib.Path] = []
+
+    def fake_reset(path):
+        calls.append(path)
+
+    monkeypatch.setattr(fs_tools, "reset_acl", fake_reset)
+    fs_tools.remove_paths([deleted, file_entry])
+
+    assert not deleted.exists()
+    assert not file_entry.exists()
+    assert calls == [deleted, file_entry]
+
+
+def test_remove_paths_dry_run(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Dry-run skip should preserve filesystem entries.
+    """
+
+    target = tmp_path / "keep.txt"
+    target.write_text("keep", encoding="utf-8")
+
+    monkeypatch.setattr(fs_tools, "reset_acl", lambda path: None)
+    fs_tools.remove_paths([target], dry_run=True)
+
+    assert target.exists()
+
+
+def test_reset_acl_invokes_icacls(monkeypatch) -> None:
+    """!
+    @brief Ensure ``icacls`` is called with expected arguments.
+    """
+
+    call_args: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        call_args.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(fs_tools.subprocess, "run", fake_run)
+    fs_tools.reset_acl(pathlib.Path("C:/temp"))
+
+    assert call_args[0][:2] == ["icacls", "C:/temp"]
+
+
+def test_terminate_office_processes_invokes_taskkill(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Process helper should execute ``taskkill`` for each process.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    commands: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(processes.subprocess, "run", fake_run)
+    processes.terminate_office_processes(["winword.exe", "excel.exe"])
+
+    assert commands
+    assert commands[0][0] == "taskkill.exe"
+    assert commands[1][0] == "taskkill.exe"
+
+
+def test_disable_tasks_respects_dry_run(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Scheduled task disablement should honour dry-run.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    called = False
+
+    def fake_run(cmd, **kwargs):
+        nonlocal called
+        called = True
+        return _Result()
+
+    monkeypatch.setattr(tasks_services.subprocess, "run", fake_run)
+    tasks_services.disable_tasks([r"Microsoft\\Office\\Task"], dry_run=True)
+
+    assert not called
+
+
+def test_disable_tasks_executes(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Without dry-run, ``schtasks`` should be invoked.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    commands: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(tasks_services.subprocess, "run", fake_run)
+    tasks_services.disable_tasks([r"Microsoft\\Office\\Task"], dry_run=False)
+
+    assert commands
+    assert commands[0][0] == "schtasks.exe"
+
+
+def test_stop_services_invokes_sc(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Service helper should call ``sc.exe`` stop and disable sequences.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    commands: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(tasks_services.subprocess, "run", fake_run)
+    tasks_services.stop_services(["ClickToRunSvc"], timeout=10)
+
+    assert len(commands) == 2
+    assert commands[0][:2] == ["sc.exe", "stop"]
+    assert commands[1][:2] == ["sc.exe", "config"]
+
+
+def test_create_restore_point_uses_powershell(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Restore point helper should call ``powershell.exe``.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    captured: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(restore_point.subprocess, "run", fake_run)
+    restore_point.create_restore_point("Before Office cleanup")
+
+    assert captured
+    assert captured[0][0] == "powershell.exe"

--- a/tests/test_scrub.py
+++ b/tests/test_scrub.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import List
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from office_janitor import logging_ext, scrub
+
+
+def test_execute_plan_runs_steps_in_order(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Ensure scrubber orchestrates restore point, process, and cleanup steps.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    events: List[str] = []
+
+    monkeypatch.setattr(
+        scrub.restore_point,
+        "create_restore_point",
+        lambda description: events.append("restore_point"),
+    )
+
+    monkeypatch.setattr(
+        scrub.processes,
+        "terminate_office_processes",
+        lambda names: events.append("terminate_processes"),
+    )
+
+    monkeypatch.setattr(
+        scrub.tasks_services,
+        "stop_services",
+        lambda services, timeout=30: events.append("stop_services"),
+    )
+
+    monkeypatch.setattr(
+        scrub.tasks_services,
+        "disable_tasks",
+        lambda tasks, dry_run=False: events.append("disable_tasks"),
+    )
+
+    monkeypatch.setattr(
+        scrub.msi_uninstall,
+        "uninstall_products",
+        lambda codes, dry_run=False: events.append(f"msi:{dry_run}"),
+    )
+
+    monkeypatch.setattr(
+        scrub.c2r_uninstall,
+        "uninstall_products",
+        lambda config, dry_run=False: events.append(f"c2r:{dry_run}"),
+    )
+
+    monkeypatch.setattr(
+        scrub.licensing,
+        "cleanup_licenses",
+        lambda metadata: events.append(f"licensing:{metadata.get('dry_run')}"),
+    )
+
+    monkeypatch.setattr(
+        scrub.fs_tools,
+        "remove_paths",
+        lambda paths, dry_run=False: events.append(f"filesystem:{dry_run}"),
+    )
+
+    plan = [
+        {
+            "id": "context",
+            "category": "context",
+            "metadata": {"options": {"create_restore_point": True}, "dry_run": False},
+        },
+        {
+            "id": "msi-0",
+            "category": "msi-uninstall",
+            "metadata": {"product": {"product_code": "{CODE}"}},
+        },
+        {
+            "id": "c2r-0",
+            "category": "c2r-uninstall",
+            "metadata": {"installation": {"release_ids": ["Test"]}},
+        },
+        {
+            "id": "licensing-0",
+            "category": "licensing-cleanup",
+            "metadata": {},
+        },
+        {
+            "id": "filesystem-0",
+            "category": "filesystem-cleanup",
+            "metadata": {"paths": [str(tmp_path / "stale")]},
+        },
+    ]
+
+    scrub.execute_plan(plan)
+
+    assert events == [
+        "restore_point",
+        "terminate_processes",
+        "stop_services",
+        "disable_tasks",
+        "msi:False",
+        "c2r:False",
+        "licensing:False",
+        "filesystem:False",
+    ]
+
+
+def test_execute_plan_dry_run_skips_mutations(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Dry-run should avoid restore/process work but still call uninstall stubs.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+
+    monkeypatch.setattr(
+        scrub.restore_point,
+        "create_restore_point",
+        lambda description: (_ for _ in ()).throw(AssertionError("restore point should not run")),
+    )
+    monkeypatch.setattr(
+        scrub.processes,
+        "terminate_office_processes",
+        lambda names: (_ for _ in ()).throw(AssertionError("terminate should not run")),
+    )
+    monkeypatch.setattr(
+        scrub.tasks_services,
+        "stop_services",
+        lambda services, timeout=30: (_ for _ in ()).throw(AssertionError("stop services should not run")),
+    )
+    monkeypatch.setattr(
+        scrub.tasks_services,
+        "disable_tasks",
+        lambda tasks, dry_run=False: (_ for _ in ()).throw(AssertionError("disable tasks should not run")),
+    )
+
+    recorded: List[str] = []
+
+    monkeypatch.setattr(
+        scrub.msi_uninstall,
+        "uninstall_products",
+        lambda codes, dry_run=False: recorded.append(f"msi:{dry_run}"),
+    )
+    monkeypatch.setattr(
+        scrub.c2r_uninstall,
+        "uninstall_products",
+        lambda config, dry_run=False: recorded.append(f"c2r:{dry_run}"),
+    )
+    monkeypatch.setattr(
+        scrub.licensing,
+        "cleanup_licenses",
+        lambda metadata: recorded.append(f"licensing:{metadata.get('dry_run')}"),
+    )
+    monkeypatch.setattr(
+        scrub.fs_tools,
+        "remove_paths",
+        lambda paths, dry_run=False: recorded.append(f"filesystem:{dry_run}"),
+    )
+
+    plan = [
+        {"id": "context", "category": "context", "metadata": {"dry_run": True}},
+        {"id": "msi-0", "category": "msi-uninstall", "metadata": {"product": {"product_code": "{CODE}"}}},
+        {"id": "c2r-0", "category": "c2r-uninstall", "metadata": {"installation": {"release_ids": ["Test"]}}},
+        {"id": "licensing-0", "category": "licensing-cleanup", "metadata": {}},
+        {"id": "filesystem-0", "category": "filesystem-cleanup", "metadata": {"paths": ["X"]}},
+    ]
+
+    scrub.execute_plan(plan, dry_run=True)
+
+    assert recorded == [
+        "msi:True",
+        "c2r:True",
+        "licensing:True",
+        "filesystem:True",
+    ]

--- a/tests/test_uninstallers.py
+++ b/tests/test_uninstallers.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import List
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from office_janitor import c2r_uninstall, logging_ext, msi_uninstall
+
+
+class _Result:
+    """!
+    @brief Simple stand-in for :class:`subprocess.CompletedProcess`.
+    """
+
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_msi_uninstall_invokes_msiexec(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Ensure MSI uninstall helper constructs the correct command line.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    calls: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(msi_uninstall.subprocess, "run", fake_run)
+    product_code = "{91160000-0011-0000-0000-0000000FF1CE}"
+    msi_uninstall.uninstall_products([product_code])
+
+    assert calls, "Expected msiexec to be invoked"
+    command = calls[0]
+    assert command[0] == msi_uninstall.MSIEXEC
+    assert "/x" in command
+    assert product_code in command
+    assert "/log" in command
+    log_path = command[command.index("/log") + 1]
+    assert log_path.endswith(".log")
+
+
+def test_msi_uninstall_respects_dry_run(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Dry-run mode should skip ``msiexec`` execution.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    called = False
+
+    def fake_run(cmd, **kwargs):
+        nonlocal called
+        called = True
+        return _Result()
+
+    monkeypatch.setattr(msi_uninstall.subprocess, "run", fake_run)
+    msi_uninstall.uninstall_products(["{91160000-0011-0000-0000-0000000FF1CE}"], dry_run=True)
+
+    assert not called, "Dry-run should not invoke msiexec"
+
+
+def test_msi_uninstall_reports_failures(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Non-zero exit codes should raise an informative error.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return _Result(returncode=1603)
+
+    monkeypatch.setattr(msi_uninstall.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        msi_uninstall.uninstall_products(["{BAD-CODE}"])
+
+    assert "BAD-CODE" in str(excinfo.value)
+
+
+def test_c2r_uninstall_constructs_command(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Validate Click-to-Run uninstall command composition and logging.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    calls: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(c2r_uninstall.subprocess, "run", fake_run)
+
+    config = {"release_ids": ["O365ProPlusRetail"]}
+    c2r_uninstall.uninstall_products(config)
+
+    assert calls, "Expected OfficeC2RClient to be invoked"
+    command = calls[0]
+    assert "OfficeC2RClient.exe" in command[0]
+    assert any(arg.startswith("productstoremove=") for arg in command)
+    assert "/log" in command
+
+
+def test_c2r_uninstall_dry_run(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Dry-run skips ``OfficeC2RClient`` execution.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    called = False
+
+    def fake_run(cmd, **kwargs):
+        nonlocal called
+        called = True
+        return _Result()
+
+    monkeypatch.setattr(c2r_uninstall.subprocess, "run", fake_run)
+    c2r_uninstall.uninstall_products({"release_ids": ["Test"]}, dry_run=True)
+
+    assert not called, "Dry-run should not invoke OfficeC2RClient"


### PR DESCRIPTION
## Summary
- add msiexec and Click-to-Run uninstall drivers with structured logging and dry-run safeguards
- flesh out licensing, filesystem, process, task, and restore point helpers to prepare the host for scrubbing
- implement plan execution orchestration and add focused unit tests covering sequencing and dry-run behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68fbee16c51483259387c698d346bc73