### PR TITLE
Ensure diagnostics artifacts and interactive guardrails

### DIFF
--- a/src/office_janitor/tui.py
+++ b/src/office_janitor/tui.py
@@ -34,7 +34,15 @@ class OfficeJanitorTUI:
         @brief Enter the TUI event loop.
         """
 
-        if not _supports_ansi() or getattr(self.app_state.get("args"), "no_color", False):
+        args = self.app_state.get("args")
+        if getattr(args, "quiet", False) or getattr(args, "json", False):
+            if self.human_logger:
+                self.human_logger.info(
+                    "Interactive TUI suppressed because quiet/json output mode was requested."
+                )
+            return
+
+        if not _supports_ansi() or getattr(args, "no_color", False):
             from . import ui
 
             if self.human_logger:


### PR DESCRIPTION
## Summary
- ensure the CLI main path persists diagnostics artifacts alongside backups
- guard interactive CLI/TUI entry points when quiet/json output is requested and share inventory context with executors
- extend integration tests covering diagnostics exports and interactive UI fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fe23624fdc83258ab1445a209c0e3a