### PR TITLE
Embed licensing template and extend cleanup tooling

### DIFF
--- a/src/office_janitor/constants.py
+++ b/src/office_janitor/constants.py
@@ -53,6 +53,17 @@ DEFAULT_OFFICE_PROCESSES = (
     "visio.exe",
     "powerpnt.exe",
 )
+"""!
+@brief Foreground Office applications terminated prior to uninstalls.
+"""
+
+OFFICE_PROCESS_PATTERNS = (
+    "ose*.exe",
+    "integrator.exe",
+)
+"""!
+@brief Wildcard process filters used to mirror OffScrub cleanup loops.
+"""
 
 MSI_UNINSTALL_ROOTS: Tuple[Tuple[int, str], ...] = (
     (HKLM, r"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall"),
@@ -349,6 +360,36 @@ KNOWN_SERVICES = (
     "ose64",
 )
 
+LICENSE_DLLS = {
+    "spp": "sppc.dll",
+    "ospp": "osppc.dll",
+}
+"""!
+@brief Default DLL names referenced by the embedded licensing PowerShell script.
+"""
+
+LICENSING_GUID_FILTERS = {
+    "office_family": "0ff1ce15-a989-479d-af46-f275c6370663",
+}
+"""!
+@brief Product family GUIDs targeted when uninstalling Office licenses.
+"""
+
+OSPP_REGISTRY_PATH = r"HKLM\\SOFTWARE\\Microsoft\\OfficeSoftwareProtectionPlatform"
+"""!
+@brief Registry location that exposes the Office Software Protection Platform path.
+"""
+
+USER_TEMPLATE_PATHS = (
+    r"%APPDATA%\\Microsoft\\Templates",
+    r"%APPDATA%\\Microsoft\\Office\\Templates",
+    r"%LOCALAPPDATA%\\Microsoft\\Office\\Licensing",
+    r"%LOCALAPPDATA%\\Microsoft\\Office\\Licenses",
+)
+"""!
+@brief Directories containing user templates and licensing state that require explicit purge consent.
+"""
+
 INSTALL_ROOT_TEMPLATES = (
     {
         "label": "c2r_root_x86",
@@ -391,6 +432,7 @@ __all__ = [
     "C2R_PRODUCT_RELEASE_ROOTS",
     "C2R_SUBSCRIPTION_ROOTS",
     "DEFAULT_OFFICE_PROCESSES",
+    "OFFICE_PROCESS_PATTERNS",
     "HKCR",
     "HKCU",
     "HKLM",
@@ -398,9 +440,13 @@ __all__ = [
     "INSTALL_ROOT_TEMPLATES",
     "KNOWN_SCHEDULED_TASKS",
     "KNOWN_SERVICES",
+    "LICENSE_DLLS",
+    "LICENSING_GUID_FILTERS",
     "MSI_PRODUCT_MAP",
     "MSI_UNINSTALL_ROOTS",
+    "OSPP_REGISTRY_PATH",
     "REGISTRY_ROOTS",
     "SUPPORTED_VERSIONS",
+    "USER_TEMPLATE_PATHS",
     "known_msi_codes",
 ]

--- a/src/office_janitor/plan.py
+++ b/src/office_janitor/plan.py
@@ -164,6 +164,8 @@ def build_plan(
                 "metadata": {
                     "paths": filesystem_entries,
                     "preserve_templates": bool(normalized_options.get("keep_templates", False)),
+                    "purge_templates": bool(normalized_options.get("force", False))
+                    and not bool(normalized_options.get("keep_templates", False)),
                     "dry_run": dry_run,
                 },
             }

--- a/src/office_janitor/scrub.py
+++ b/src/office_janitor/scrub.py
@@ -89,6 +89,7 @@ def execute_plan(
                 human_logger.warning("Failed to create restore point: %s", exc)
 
         processes.terminate_office_processes(constants.DEFAULT_OFFICE_PROCESSES)
+        processes.terminate_process_patterns(constants.OFFICE_PROCESS_PATTERNS)
         tasks_services.stop_services(constants.KNOWN_SERVICES)
         tasks_services.disable_tasks(constants.KNOWN_SCHEDULED_TASKS, dry_run=False)
 

--- a/tests/test_cleanup_tools.py
+++ b/tests/test_cleanup_tools.py
@@ -9,7 +9,15 @@ SRC_PATH = PROJECT_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
-from office_janitor import fs_tools, licensing, logging_ext, processes, restore_point, tasks_services
+from office_janitor import (
+    constants,
+    fs_tools,
+    licensing,
+    logging_ext,
+    processes,
+    restore_point,
+    tasks_services,
+)
 
 
 class _Result:
@@ -74,6 +82,17 @@ def test_cleanup_licenses_dry_run(monkeypatch, tmp_path) -> None:
     assert not called
 
 
+def test_render_license_script_defaults_to_constants() -> None:
+    """!
+    @brief Ensure the embedded PowerShell script references constant values.
+    """
+
+    script = licensing._render_license_script({})
+    assert constants.LICENSING_GUID_FILTERS["office_family"] in script
+    assert constants.LICENSE_DLLS["spp"] in script
+    assert constants.OSPP_REGISTRY_PATH in script
+
+
 def test_remove_paths_deletes_entries(monkeypatch, tmp_path) -> None:
     """!
     @brief Filesystem helper should remove files and directories.
@@ -86,16 +105,22 @@ def test_remove_paths_deletes_entries(monkeypatch, tmp_path) -> None:
     file_entry.write_text("payload", encoding="utf-8")
 
     calls: List[pathlib.Path] = []
+    attrib_calls: List[List[pathlib.Path]] = []
 
     def fake_reset(path):
         calls.append(path)
 
+    def fake_make(paths, *, dry_run: bool = False):
+        attrib_calls.append([pathlib.Path(p) for p in paths])
+
+    monkeypatch.setattr(fs_tools, "make_paths_writable", fake_make)
     monkeypatch.setattr(fs_tools, "reset_acl", fake_reset)
     fs_tools.remove_paths([deleted, file_entry])
 
     assert not deleted.exists()
     assert not file_entry.exists()
     assert calls == [deleted, file_entry]
+    assert attrib_calls
 
 
 def test_remove_paths_dry_run(monkeypatch, tmp_path) -> None:
@@ -106,10 +131,19 @@ def test_remove_paths_dry_run(monkeypatch, tmp_path) -> None:
     target = tmp_path / "keep.txt"
     target.write_text("keep", encoding="utf-8")
 
+    make_called = False
+
+    def fake_make(paths, *, dry_run: bool = False):
+        nonlocal make_called
+        make_called = True
+        assert dry_run is True
+
+    monkeypatch.setattr(fs_tools, "make_paths_writable", fake_make)
     monkeypatch.setattr(fs_tools, "reset_acl", lambda path: None)
     fs_tools.remove_paths([target], dry_run=True)
 
     assert target.exists()
+    assert make_called is False
 
 
 def test_reset_acl_invokes_icacls(monkeypatch) -> None:
@@ -127,6 +161,27 @@ def test_reset_acl_invokes_icacls(monkeypatch) -> None:
     fs_tools.reset_acl(pathlib.Path("C:/temp"))
 
     assert call_args[0][:2] == ["icacls", "C:/temp"]
+
+
+def test_make_paths_writable_invokes_attrib(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Attribute clearing should call ``attrib.exe`` for directories and contents.
+    """
+
+    commands: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return _Result()
+
+    target = tmp_path / "dir"
+    target.mkdir()
+
+    monkeypatch.setattr(fs_tools.subprocess, "run", fake_run)
+    fs_tools.make_paths_writable([target])
+
+    assert commands
+    assert commands[0][:2] == ["attrib.exe", "-R"]
 
 
 def test_terminate_office_processes_invokes_taskkill(monkeypatch, tmp_path) -> None:
@@ -147,6 +202,35 @@ def test_terminate_office_processes_invokes_taskkill(monkeypatch, tmp_path) -> N
     assert commands
     assert commands[0][0] == "taskkill.exe"
     assert commands[1][0] == "taskkill.exe"
+
+
+def test_terminate_process_patterns_uses_tasklist(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Wildcard termination should enumerate processes before invoking taskkill.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    enumerations: List[List[str]] = []
+    killed: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0].lower() == "tasklist.exe":
+            enumerations.append(cmd)
+            return _Result(
+                stdout="""Image Name                     PID Session Name        Session#    Mem Usage\nose.exe 123 Console                    1     12,000 K\nIntegrator.exe 456 Console                    1     15,000 K\n""",
+            )
+        raise AssertionError("Unexpected command")
+
+    def fake_terminate(names, *, timeout=30):
+        killed.append(list(names))
+
+    monkeypatch.setattr(processes.subprocess, "run", fake_run)
+    monkeypatch.setattr(processes, "terminate_office_processes", fake_terminate)
+
+    processes.terminate_process_patterns(["ose*.exe", "integrator.exe"])
+
+    assert enumerations
+    assert killed == [["ose.exe", "integrator.exe"]]
 
 
 def test_disable_tasks_respects_dry_run(monkeypatch, tmp_path) -> None:
@@ -187,6 +271,25 @@ def test_disable_tasks_executes(monkeypatch, tmp_path) -> None:
     assert commands[0][0] == "schtasks.exe"
 
 
+def test_remove_tasks_executes_delete(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Task deletion should issue ``schtasks /Delete`` commands.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    commands: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(tasks_services.subprocess, "run", fake_run)
+    tasks_services.remove_tasks([r"Microsoft\\Office\\Cleanup"], dry_run=False)
+
+    assert commands
+    assert commands[0][:2] == ["schtasks.exe", "/Delete"]
+
+
 def test_stop_services_invokes_sc(monkeypatch, tmp_path) -> None:
     """!
     @brief Service helper should call ``sc.exe`` stop and disable sequences.
@@ -205,6 +308,25 @@ def test_stop_services_invokes_sc(monkeypatch, tmp_path) -> None:
     assert len(commands) == 2
     assert commands[0][:2] == ["sc.exe", "stop"]
     assert commands[1][:2] == ["sc.exe", "config"]
+
+
+def test_delete_services_executes(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Service deletion should issue ``sc.exe delete``.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    commands: List[List[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(tasks_services.subprocess, "run", fake_run)
+    tasks_services.delete_services(["ose"], dry_run=False)
+
+    assert commands
+    assert commands[0][:2] == ["sc.exe", "delete"]
 
 
 def test_create_restore_point_uses_powershell(monkeypatch, tmp_path) -> None:

--- a/tests/test_registry_tools.py
+++ b/tests/test_registry_tools.py
@@ -1,23 +1,76 @@
 """!
-@brief Registry tooling scaffolding tests.
-@details Placeholder coverage for backup, export, and restore simulations across supported registries.
+@brief Registry tooling tests covering cleanup utilities.
+@details Validates dry-run behaviour and command invocation for registry export
+and delete helpers using mocked ``reg.exe`` availability.
 """
 
-import pytest
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import List
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from office_janitor import registry_tools  # noqa: E402
 
 
-@pytest.mark.skip(reason="Placeholder for registry backup and export scenarios.")
-class TestRegistryTooling:
+class _Result:
     """!
-    @brief Registry tool simulation scenarios.
-    @details Will validate backup/export orchestration, error handling, and cross-architecture registry
-    hive support once tooling logic is implemented.
+    @brief Stub ``CompletedProcess`` for command tracking.
     """
 
-    def test_registry_tooling_placeholder(self) -> None:
-        """!
-        @brief Placeholder registry tooling test.
-        @details Ensures backup and export flows integrate with detection and planning stages without
-        side effects during simulations.
-        """
-        pytest.skip("Placeholder for registry backup and export scenarios.")
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
+
+
+def test_delete_keys_invokes_reg_when_available(monkeypatch) -> None:
+    """!
+    @brief Deletion should call ``reg delete`` when the binary exists.
+    """
+
+    commands: List[List[str]] = []
+
+    monkeypatch.setattr(registry_tools.shutil, "which", lambda exe: "reg.exe")
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(registry_tools.subprocess, "run", fake_run)
+
+    registry_tools.delete_keys(["HKLM\\Software\\Contoso"], dry_run=False)
+
+    assert commands == [["reg.exe", "delete", "HKLM\\Software\\Contoso", "/f"]]
+
+
+def test_delete_keys_dry_run_skips_execution(monkeypatch) -> None:
+    """!
+    @brief Dry-run should avoid invoking ``reg.exe``.
+    """
+
+    monkeypatch.setattr(registry_tools.shutil, "which", lambda exe: "reg.exe")
+
+    def fake_run(cmd, **kwargs):  # pragma: no cover - ensure not called
+        raise AssertionError("reg.exe should not be invoked during dry-run")
+
+    monkeypatch.setattr(registry_tools.subprocess, "run", fake_run)
+
+    registry_tools.delete_keys(["HKCU\\Software\\Tailspin"], dry_run=True)
+
+
+def test_export_keys_creates_placeholder_when_reg_missing(tmp_path, monkeypatch) -> None:
+    """!
+    @brief Exports should produce placeholder files if ``reg.exe`` is absent.
+    """
+
+    monkeypatch.setattr(registry_tools.shutil, "which", lambda exe: None)
+
+    registry_tools.export_keys(["HKLM\\Software\\Fabrikam"], str(tmp_path))
+
+    export_file = tmp_path / "HKLM_Software_Fabrikam.reg"
+    assert export_file.exists()
+    assert "Placeholder export" in export_file.read_text(encoding="utf-8")

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -215,6 +215,98 @@ class TestSafetyPreflight:
         with pytest.raises(ValueError):
             safety.perform_preflight_checks(plan_steps)
 
+    def test_preflight_blocks_template_cleanup_without_consent(self) -> None:
+        """!
+        @brief User template cleanup must be explicitly authorised.
+        """
+
+        plan_steps = [
+            {
+                "id": "context",
+                "category": "context",
+                "metadata": {
+                    "dry_run": False,
+                    "mode": "auto-all",
+                    "target_versions": [],
+                    "unsupported_targets": [],
+                    "options": {"force": False, "keep_templates": False},
+                },
+            },
+            {
+                "id": "filesystem-0",
+                "category": "filesystem-cleanup",
+                "metadata": {
+                    "paths": [r"C:\\Users\\Alice\\AppData\\Roaming\\Microsoft\\Templates"],
+                    "dry_run": False,
+                    "purge_templates": False,
+                },
+            },
+        ]
+
+        with pytest.raises(ValueError):
+            safety.perform_preflight_checks(plan_steps)
+
+    def test_preflight_allows_forced_template_cleanup(self) -> None:
+        """!
+        @brief Force flag should permit template cleanup steps.
+        """
+
+        plan_steps = [
+            {
+                "id": "context",
+                "category": "context",
+                "metadata": {
+                    "dry_run": False,
+                    "mode": "auto-all",
+                    "target_versions": [],
+                    "unsupported_targets": [],
+                    "options": {"force": True, "keep_templates": False},
+                },
+            },
+            {
+                "id": "filesystem-0",
+                "category": "filesystem-cleanup",
+                "metadata": {
+                    "paths": [r"C:\\Users\\Alice\\AppData\\Roaming\\Microsoft\\Templates"],
+                    "dry_run": False,
+                    "purge_templates": True,
+                },
+            },
+        ]
+
+        safety.perform_preflight_checks(plan_steps)
+
+    def test_preflight_honours_preserve_templates_flag(self) -> None:
+        """!
+        @brief Preserve flag should block template deletion even with cleanup steps present.
+        """
+
+        plan_steps = [
+            {
+                "id": "context",
+                "category": "context",
+                "metadata": {
+                    "dry_run": False,
+                    "mode": "auto-all",
+                    "target_versions": [],
+                    "unsupported_targets": [],
+                    "options": {"force": False, "keep_templates": True},
+                },
+            },
+            {
+                "id": "filesystem-0",
+                "category": "filesystem-cleanup",
+                "metadata": {
+                    "paths": [r"C:\\Users\\Alice\\AppData\\Roaming\\Microsoft\\Templates"],
+                    "dry_run": False,
+                    "preserve_templates": True,
+                },
+            },
+        ]
+
+        with pytest.raises(ValueError):
+            safety.perform_preflight_checks(plan_steps)
+
     def test_preflight_requires_targeted_uninstall(self) -> None:
         """!
         @brief Target mode without uninstall steps is invalid.


### PR DESCRIPTION
## Summary
- embed the CleanOffice PowerShell logic as a parameterised template in the licensing module and wire it to constants
- harden filesystem/process/task/service cleanup helpers to mirror OffScrub patterns and respect dry-run behaviour
- enforce template safety guards in planning/safety checks and add targeted cleanup and registry tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fe5daa1ce0832598781109c630ebe3