### PR TITLE
Expose version metadata utilities

### DIFF
--- a/src/office_janitor/main.py
+++ b/src/office_janitor/main.py
@@ -97,11 +97,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
     """
 
     parser = argparse.ArgumentParser(prog="office-janitor", add_help=True)
+    metadata = version.build_info()
     parser.add_argument(
         "-V",
         "--version",
         action="version",
-        version=f"{version.__version__} ({version.__build__})",
+        version=f"{metadata['version']} ({metadata['build']})",
     )
 
     modes = parser.add_mutually_exclusive_group()

--- a/src/office_janitor/ui.py
+++ b/src/office_janitor/ui.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import textwrap
 from typing import Callable, Mapping, MutableMapping
 
+from . import version
+
 
 MenuHandler = Callable[[MutableMapping[str, object]], None]
 
@@ -79,9 +81,12 @@ def _print_menu(menu: list[tuple[str, MenuHandler]]) -> None:
     @brief Render the text menu to stdout.
     """
 
+    metadata = version.build_info()
     header = textwrap.dedent(
-        """
+        f"""
         ================= Office Janitor =================
+        Version {metadata['version']} (build {metadata['build']})
+        --------------------------------------------------
         1. Detect & show installed Office
         2. Auto scrub everything detected (recommended)
         3. Targeted scrub (choose versions/components)

--- a/src/office_janitor/version.py
+++ b/src/office_janitor/version.py
@@ -1,10 +1,22 @@
 """!
 @brief Version metadata for Office Janitor.
-@details The version module exposes build identifiers for CLI reporting and
-packaging integration, matching the specification's requirement for
-``-V/--version`` output.
+@details The version module centralizes version and build identifiers so that
+the command-line interface and user interfaces present consistent information.
 """
 from __future__ import annotations
 
+from typing import Dict
+
+__all__ = ["__version__", "__build__", "build_info"]
+
 __version__ = "0.0.0"
 __build__ = "dev"
+
+
+def build_info() -> Dict[str, str]:
+    """!
+    @brief Provide a mapping with the current version metadata.
+    @returns Dictionary containing ``version`` and ``build`` keys.
+    """
+
+    return {"version": __version__, "build": __build__}

--- a/tests/test_main_and_ui.py
+++ b/tests/test_main_and_ui.py
@@ -6,12 +6,14 @@ import pathlib
 import sys
 from typing import List
 
+import pytest
+
 PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
 SRC_PATH = PROJECT_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
-from office_janitor import main, ui  # noqa: E402
+from office_janitor import main, ui, version  # noqa: E402
 from office_janitor import tui as tui_module  # noqa: E402
 
 
@@ -164,6 +166,32 @@ def test_arg_parser_and_plan_options_cover_modes() -> None:
     assert options["keep_templates"] is True
     assert options["timeout"] == 90
     assert options["backup"] == "C:/backup"
+
+
+def test_version_option_reports_metadata(capsys) -> None:
+    """!
+    @brief ``--version`` should surface both version and build identifiers.
+    """
+
+    parser = main.build_arg_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--version"])
+    output = capsys.readouterr().out
+    info = version.build_info()
+    assert info["version"] in output
+    assert info["build"] in output
+
+
+def test_ui_header_displays_build_info(capsys) -> None:
+    """!
+    @brief The interactive menu header should mention version metadata.
+    """
+
+    ui._print_menu([])
+    output = capsys.readouterr().out
+    info = version.build_info()
+    assert info["version"] in output
+    assert info["build"] in output
 
 
 def test_main_target_mode_passes_all_options(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- centralize version and build metadata in `office_janitor.version.build_info`
- surface build metadata through the CLI --version flag and UI headers
- extend CLI/UI integration tests to validate reported build information

## Testing
- pytest tests/test_main_and_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68fe9d911b808325b233d860d5e692f2