### PR TITLE
Centralize Office constants and helpers

### DIFF
--- a/src/office_janitor/c2r_uninstall.py
+++ b/src/office_janitor/c2r_uninstall.py
@@ -11,23 +11,13 @@ import time
 from pathlib import Path
 from typing import Iterable, List, Mapping, Sequence
 
-from . import logging_ext
+from . import constants, logging_ext
+
+OFFSCRUB_C2R_ARGS = constants.C2R_OFFSCRUB_ARGS
+"""!
+@brief Backwards-compatible alias for Click-to-Run OffScrub arguments.
+"""
 from .off_scrub_scripts import ensure_offscrub_script
-
-CSCRIPT = "cscript.exe"
-"""!
-@brief Host executable for OffScrub VBS helpers.
-"""
-
-OFFSCRUB_C2R_SCRIPT = "OffScrubC2R.vbs"
-"""!
-@brief Click-to-Run OffScrub helper name mirrored from the reference script.
-"""
-
-OFFSCRUB_C2R_ARGS: tuple[str, ...] = ("ALL", "/OFFLINE")
-"""!
-@brief Arguments used by ``OffScrubC2R.vbs`` inside ``OfficeScrubber.cmd``.
-"""
 
 C2R_TIMEOUT = 3600
 """!
@@ -62,10 +52,14 @@ def build_command(
         or config.get("ProductReleaseIds")
     )
 
-    script_path = ensure_offscrub_script(OFFSCRUB_C2R_SCRIPT, base_directory=script_directory)
+    script_path = ensure_offscrub_script(
+        constants.C2R_OFFSCRUB_SCRIPT, base_directory=script_directory
+    )
 
-    command: List[str] = [str(CSCRIPT), "//NoLogo", str(script_path)]
-    command.extend(OFFSCRUB_C2R_ARGS)
+    command: List[str] = [str(constants.OFFSCRUB_EXECUTABLE)]
+    command.extend(str(arg) for arg in constants.OFFSCRUB_HOST_ARGS)
+    command.append(str(script_path))
+    command.extend(constants.C2R_OFFSCRUB_ARGS)
     if release_ids:
         command.append(f"/PRODUCTS={';'.join(release_ids)}")
     return command

--- a/src/office_janitor/detect.py
+++ b/src/office_janitor/detect.py
@@ -142,6 +142,7 @@ def detect_msi_installations() -> List[DetectedInstallation]:
             display_name = str(values.get("DisplayName") or metadata.get("product") or product_code)
             display_version = str(values.get("DisplayVersion") or "")
             uninstall_string = str(values.get("UninstallString") or "")
+            family = constants.resolve_msi_family(product_code) or str(metadata.get("family", ""))
 
             properties: Dict[str, object] = {
                 "display_name": display_name,
@@ -151,6 +152,8 @@ def detect_msi_installations() -> List[DetectedInstallation]:
                 properties["uninstall_string"] = uninstall_string
             properties["supported_versions"] = list(metadata.get("supported_versions", ()))
             properties["edition"] = metadata.get("edition", "")
+            if family:
+                properties["family"] = family
 
             installations.append(
                 DetectedInstallation(
@@ -217,6 +220,9 @@ def detect_c2r_installations() -> List[DetectedInstallation]:
             supported_architectures = tuple(
                 str(a) for a in (product_metadata or {}).get("architectures", ())
             )
+            family = constants.resolve_c2r_family(release_id) or str(
+                (product_metadata or {}).get("family", "")
+            )
             uninstall_handles = [_compose_handle(hive, config_path)]
 
             registry_paths = (product_metadata or {}).get("registry_paths", {})
@@ -238,6 +244,8 @@ def detect_c2r_installations() -> List[DetectedInstallation]:
                 properties["package_guid"] = package_guid
             if install_path:
                 properties["install_path"] = install_path
+            if family:
+                properties["family"] = family
 
             installations.append(
                 DetectedInstallation(

--- a/src/office_janitor/plan.py
+++ b/src/office_janitor/plan.py
@@ -8,17 +8,10 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, List, Mapping, Sequence
 
-SUPPORTED_TARGET_VERSIONS = {
-    "2003",
-    "2007",
-    "2010",
-    "2013",
-    "2016",
-    "2019",
-    "2021",
-    "2024",
-    "365",
-}
+from . import constants
+
+_SUPPORTED_TARGETS = tuple(constants.SUPPORTED_TARGETS)
+_SUPPORTED_TARGET_SET = {str(value) for value in _SUPPORTED_TARGETS}
 
 _C2R_RELEASE_HINTS = {
     "o365": "365",
@@ -282,7 +275,7 @@ def _resolve_targets(mode: str, options: Mapping[str, object]) -> tuple[List[str
             ordered_targets.append(candidate_norm)
 
     for candidate in ordered_targets:
-        if candidate not in SUPPORTED_TARGET_VERSIONS:
+        if candidate not in _SUPPORTED_TARGET_SET:
             unsupported.append(candidate)
 
     valid_targets = [candidate for candidate in ordered_targets if candidate not in unsupported]
@@ -319,10 +312,10 @@ def _infer_version(record: Mapping[str, object]) -> str:
         if not value:
             continue
         value_str = str(value)
-        if value_str in SUPPORTED_TARGET_VERSIONS:
+        if value_str in _SUPPORTED_TARGET_SET:
             return value_str
         major_component = value_str.split(".", 1)[0]
-        if major_component in SUPPORTED_TARGET_VERSIONS:
+        if major_component in _SUPPORTED_TARGET_SET:
             return major_component
         if not fallback_value:
             fallback_value = value_str
@@ -331,7 +324,7 @@ def _infer_version(record: Mapping[str, object]) -> str:
     if isinstance(tags, Iterable) and not isinstance(tags, (str, bytes)):
         for tag in tags:
             tag_str = str(tag)
-            if tag_str in SUPPORTED_TARGET_VERSIONS:
+            if tag_str in _SUPPORTED_TARGET_SET:
                 return tag_str
 
     release_ids = record.get("release_ids")

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from office_janitor import constants
+
+
+class TestConstantsModule:
+    """!
+    @brief Validate helpers exposed from :mod:`office_janitor.constants`.
+    """
+
+    @pytest.mark.parametrize(
+        "product_code,expected",
+        [
+            ("{90160000-0011-0000-0000-0000000FF1CE}", "office"),
+            ("901600000011000000000000000FF1CE", "office"),
+            ("{90160000-003B-0000-0000-0000000FF1CE}", "project"),
+        ],
+    )
+    def test_resolve_msi_family(self, product_code: str, expected: str) -> None:
+        """!
+        @brief MSI product codes map to stable families.
+        """
+
+        assert constants.resolve_msi_family(product_code) == expected
+
+    def test_resolve_c2r_family(self) -> None:
+        """!
+        @brief Click-to-Run releases expose family metadata.
+        """
+
+        assert constants.resolve_c2r_family("ProjectProRetail") == "project"
+        assert constants.resolve_c2r_family("VisioProRetail") == "visio"
+
+    @pytest.mark.parametrize(
+        "component,expected",
+        [
+            ("visio", "visio"),
+            ("MSI-Project", "project"),
+            ("OneNote2016", "onenote"),
+        ],
+    )
+    def test_component_normalisation(self, component: str, expected: str) -> None:
+        """!
+        @brief Optional component aliases resolve to supported identifiers.
+        """
+
+        assert constants.resolve_supported_component(component) == expected
+        assert constants.is_supported_component(component) is True
+
+    def test_supported_components_iterable(self) -> None:
+        """!
+        @brief Helper exposes default optional components.
+        """
+
+        entries = constants.iter_supported_components()
+        assert set(entries) == set(constants.SUPPORTED_COMPONENTS)
+
+    def test_uninstall_command_templates_expose_expected_metadata(self) -> None:
+        """!
+        @brief Uninstall command templates provide OffScrub wiring.
+        """
+
+        msi_template = constants.UNINSTALL_COMMAND_TEMPLATES["msi"]
+        assert msi_template["executable"] == constants.OFFSCRUB_EXECUTABLE
+        assert constants.MSI_OFFSCRUB_DEFAULT_SCRIPT in set(
+            msi_template["script_map"].values()
+        )
+
+        c2r_template = constants.UNINSTALL_COMMAND_TEMPLATES["c2r"]
+        assert c2r_template["script"] == constants.C2R_OFFSCRUB_SCRIPT
+        assert tuple(c2r_template["arguments"]) == constants.C2R_OFFSCRUB_ARGS


### PR DESCRIPTION
## Summary
- expand `constants.py` with shared uninstall command templates, product family metadata, and supported target/component aliases
- update detection and uninstall orchestrators to consume the centralized constants and expose compatibility aliases
- refactor planning target validation to reuse the new supported target list and add unit tests covering the helper lookups

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fea34ac1f883258d8820ca97ea2c5b