### PR TITLE
Enhance registry tooling with safety-aware exports and filters

### DIFF
--- a/src/office_janitor/registry_tools.py
+++ b/src/office_janitor/registry_tools.py
@@ -1,16 +1,23 @@
 """!
 @brief Registry management helpers.
-@details The registry tools export hives for backup, delete targeted keys, and
-provide winreg utilities used throughout detection and cleanup as outlined in
-the specification.
+@details Implements the registry wrappers, filters, and guard-railed backup
+and delete routines described in :mod:`spec.md`. The helpers abstract winreg
+view handling so callers can reason about 32-bit and 64-bit hives uniformly
+while also exposing convenience predicates for Office-specific uninstall
+entries. All operations honour the dry-run and safety constraints enforced by
+``office_janitor.safety``.
 """
 from __future__ import annotations
 
+import logging
+import re
 import shutil
 import subprocess
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Tuple
+
+from . import safety
 
 try:  # pragma: no cover - exercised through mocks on non-Windows platforms.
     import winreg
@@ -18,8 +25,42 @@ except ImportError:  # pragma: no cover - handled gracefully during tests.
     winreg = None  # type: ignore[assignment]
 
 
+_LOGGER = logging.getLogger(__name__)
+
+_CANONICAL_PREFIXES: Mapping[str, str] = {
+    "HKEY_LOCAL_MACHINE": "HKLM",
+    "HKLM": "HKLM",
+    "HKEY_CURRENT_USER": "HKCU",
+    "HKCU": "HKCU",
+    "HKEY_CLASSES_ROOT": "HKCR",
+    "HKCR": "HKCR",
+    "HKEY_USERS": "HKU",
+    "HKU": "HKU",
+}
+
+_SAFE_FILENAME_PATTERN = re.compile(r"[^A-Z0-9._-]+")
+
+_OFFICE_KEYWORDS = (
+    "office",
+    "microsoft 365",
+    "365",
+    "visio",
+    "project",
+    "onenote",
+    "word",
+    "excel",
+    "outlook",
+    "powerpoint",
+)
+
+class RegistryError(RuntimeError):
+    """!
+    @brief Raised when registry operations cannot be completed safely.
+    """
+
+
 def _ensure_winreg() -> None:
-    """!  
+    """!
     @brief Raise an informative error when ``winreg`` is unavailable.
     """
 
@@ -27,111 +68,229 @@ def _ensure_winreg() -> None:
         raise FileNotFoundError("Windows registry APIs are unavailable on this platform")
 
 
-def export_keys(keys: Iterable[str], destination: str) -> None:
+def _normalize_registry_key(key: str) -> str:
     """!
-    @brief Export the provided registry keys to ``.reg`` files in ``destination``.
-    @details On non-Windows systems the exports become placeholder files so unit
-    tests and dry-run flows can still verify orchestration logic without access
-    to the native ``reg.exe`` utility.
+    @brief Canonicalise registry key strings to ``HKXX`` prefixes.
     """
 
-    dest_path = Path(destination)
-    dest_path.mkdir(parents=True, exist_ok=True)
-    reg_executable = shutil.which("reg")
-
-    for key in keys:
-        safe_name = key.replace("\\", "_").replace("/", "_")
-        export_path = dest_path / f"{safe_name}.reg"
-        if reg_executable:
-            subprocess.run(
-                [reg_executable, "export", key, str(export_path), "/y"],
-                check=True,
-            )
-        else:  # pragma: no cover - depends on environment availability.
-            export_path.write_text(
-                f"; Placeholder export for {key}\n",
-                encoding="utf-8",
-            )
+    cleaned = key.strip().replace("/", "\\")
+    while "\\\\" in cleaned:
+        cleaned = cleaned.replace("\\\\", "\\")
+    cleaned = cleaned.rstrip("\\")
+    upper = cleaned.upper()
+    for prefix, canonical in _CANONICAL_PREFIXES.items():
+        if upper.startswith(prefix):
+            suffix = upper[len(prefix) :].lstrip("\\")
+            return f"{canonical}\\{suffix}" if suffix else canonical
+    return upper
 
 
-def delete_keys(keys: Iterable[str], *, dry_run: bool = False) -> None:
+def _normalize_for_comparison(key: str) -> str:
     """!
-    @brief Remove registry keys while respecting dry-run safeguards.
+    @brief Provide a uppercase normalisation used for safety checks.
     """
 
-    reg_executable = shutil.which("reg")
+    canonical = _normalize_registry_key(key)
+    return canonical.upper()
 
+
+_ALLOWED_REGISTRY_PREFIXES = tuple(_normalize_registry_key(entry) for entry in safety.REGISTRY_WHITELIST)
+_BLOCKED_REGISTRY_PREFIXES = tuple(_normalize_registry_key(entry) for entry in safety.REGISTRY_BLACKLIST)
+
+
+def _is_registry_path_allowed(key: str) -> bool:
+    """!
+    @brief Validate the registry path against the whitelist/blacklist rules.
+    """
+
+    normalized = _normalize_for_comparison(key)
+    if any(normalized.startswith(blocked) for blocked in _BLOCKED_REGISTRY_PREFIXES):
+        return False
+    return any(normalized.startswith(allowed) for allowed in _ALLOWED_REGISTRY_PREFIXES)
+
+
+def _validate_registry_keys(keys: Iterable[str]) -> List[str]:
+    """!
+    @brief Ensure all keys fall within the allowed registry scope.
+    """
+
+    canonical_keys: List[str] = []
     for key in keys:
-        if dry_run or not reg_executable:
+        canonical = _normalize_registry_key(key)
+        if not _is_registry_path_allowed(canonical):
+            raise RegistryError(f"Refusing to operate on non-whitelisted registry key: {key}")
+        canonical_keys.append(canonical)
+    return canonical_keys
+
+
+def _iter_access_masks(access: int, view: str | None) -> Iterator[int]:
+    """!
+    @brief Yield candidate access masks for the requested WOW64 view.
+    """
+
+    if winreg is None:  # pragma: no cover - defensive guard for type checkers.
+        return iter(())
+
+    view = (view or "auto").lower()
+    if view not in {"auto", "native", "32bit", "64bit", "both"}:
+        raise ValueError(f"Unsupported registry view: {view}")
+
+    masks: List[int] = []
+    native_mask = access
+    wow64_32 = getattr(winreg, "KEY_WOW64_32KEY", 0)
+    wow64_64 = getattr(winreg, "KEY_WOW64_64KEY", 0)
+
+    if view in {"native", "auto"}:
+        masks.append(native_mask)
+    if view in {"32bit", "both", "auto"} and wow64_32:
+        masks.append(access | wow64_32)
+    if view in {"64bit", "both", "auto"} and wow64_64:
+        masks.append(access | wow64_64)
+
+    seen: set[int] = set()
+    for mask in masks:
+        if mask in seen:
             continue
-        subprocess.run([reg_executable, "delete", key, "/f"], check=True)
+        seen.add(mask)
+        yield mask
 
 
 @contextmanager
-def open_key(root: int, path: str, access: int | None = None) -> Iterator[Any]:
+def open_key(root: int, path: str, *, access: int | None = None, view: str | None = None) -> Iterator[Any]:
     """!
-    @brief Context manager that mirrors ``winreg.OpenKey`` while ensuring
-    handles are closed correctly.
+    @brief Context manager that mirrors ``winreg.OpenKey`` with view handling.
     """
 
     _ensure_winreg()
-    access_mask = access if access is not None else winreg.KEY_READ  # type: ignore[union-attr]
-    handle = winreg.OpenKey(root, path, 0, access_mask)  # type: ignore[union-attr]
-    try:
-        yield handle
-    finally:
-        winreg.CloseKey(handle)  # type: ignore[union-attr]
+    mask = access if access is not None else winreg.KEY_READ  # type: ignore[union-attr]
+    last_error: Exception | None = None
+
+    for candidate in _iter_access_masks(mask, view):
+        try:
+            handle = winreg.OpenKey(root, path, 0, candidate)  # type: ignore[union-attr]
+        except FileNotFoundError as exc:
+            last_error = exc
+            continue
+        except OSError as exc:  # pragma: no cover - depends on host registry state.
+            last_error = exc
+            continue
+        else:
+            try:
+                yield handle
+            finally:
+                winreg.CloseKey(handle)  # type: ignore[union-attr]
+            return
+
+    if last_error is not None:
+        raise last_error
+    raise FileNotFoundError(path)
 
 
-def iter_subkeys(root: int, path: str) -> Iterator[str]:
+def iter_subkeys(root: int, path: str, *, view: str | None = None) -> Iterator[str]:
     """!
-    @brief Yield subkey names for ``root``/``path``.
+    @brief Yield subkey names for ``root``/``path`` across WOW64 views.
     """
 
     _ensure_winreg()
-    with open_key(root, path) as handle:
-        subkey_count, _, _ = winreg.QueryInfoKey(handle)  # type: ignore[union-attr]
-        for index in range(subkey_count):
-            yield winreg.EnumKey(handle, index)  # type: ignore[union-attr]
+    yielded: set[str] = set()
+    found = False
+
+    for candidate in _iter_access_masks(winreg.KEY_READ, view):  # type: ignore[union-attr]
+        try:
+            handle = winreg.OpenKey(root, path, 0, candidate)  # type: ignore[union-attr]
+        except FileNotFoundError:
+            continue
+        except OSError:  # pragma: no cover - depends on registry permissions.
+            continue
+        else:
+            found = True
+            try:
+                index = 0
+                while True:
+                    try:
+                        name = winreg.EnumKey(handle, index)  # type: ignore[union-attr]
+                    except OSError:
+                        break
+                    index += 1
+                    if name in yielded:
+                        continue
+                    yielded.add(name)
+                    yield name
+            finally:
+                winreg.CloseKey(handle)  # type: ignore[union-attr]
+
+    if not found:
+        raise FileNotFoundError(path)
 
 
-def iter_values(root: int, path: str) -> Iterator[Tuple[str, Any]]:
+def iter_values(root: int, path: str, *, view: str | None = None) -> Iterator[Tuple[str, Any]]:
     """!
-    @brief Yield value name/value pairs for ``root``/``path``.
+    @brief Yield value name/value pairs for ``root``/``path`` across WOW64 views.
     """
 
     _ensure_winreg()
-    with open_key(root, path) as handle:
-        _, value_count, _ = winreg.QueryInfoKey(handle)  # type: ignore[union-attr]
-        for index in range(value_count):
-            name, value, _ = winreg.EnumValue(handle, index)  # type: ignore[union-attr]
-            yield name, value
+    seen: set[str] = set()
+    found = False
+
+    for candidate in _iter_access_masks(winreg.KEY_READ, view):  # type: ignore[union-attr]
+        try:
+            handle = winreg.OpenKey(root, path, 0, candidate)  # type: ignore[union-attr]
+        except FileNotFoundError:
+            continue
+        except OSError:  # pragma: no cover - depends on registry permissions.
+            continue
+        else:
+            found = True
+            try:
+                index = 0
+                while True:
+                    try:
+                        name, value, _ = winreg.EnumValue(handle, index)  # type: ignore[union-attr]
+                    except OSError:
+                        break
+                    index += 1
+                    if name in seen:
+                        continue
+                    seen.add(name)
+                    yield name, value
+            finally:
+                winreg.CloseKey(handle)  # type: ignore[union-attr]
+
+    if not found:
+        raise FileNotFoundError(path)
 
 
-def read_values(root: int, path: str) -> Dict[str, Any]:
+def read_values(root: int, path: str, *, view: str | None = None) -> Dict[str, Any]:
     """!
     @brief Read all values beneath ``root``/``path`` into a dictionary.
     """
 
-    data: Dict[str, Any] = {}
+    values: Dict[str, Any] = {}
     try:
-        for name, value in iter_values(root, path):
-            data[name] = value
+        for name, value in iter_values(root, path, view=view):
+            values.setdefault(name, value)
     except FileNotFoundError:
         return {}
     except OSError:
         return {}
-    return data
+    return values
 
 
-def get_value(root: int, path: str, value_name: str, default: Any | None = None) -> Any | None:
+def get_value(
+    root: int,
+    path: str,
+    value_name: str,
+    default: Any | None = None,
+    *,
+    view: str | None = None,
+) -> Any | None:
     """!
     @brief Read ``value_name`` beneath ``root``/``path``.
     """
 
     try:
         _ensure_winreg()
-        with open_key(root, path) as handle:
+        with open_key(root, path, view=view) as handle:
             value, _ = winreg.QueryValueEx(handle, value_name)  # type: ignore[union-attr]
             return value
     except FileNotFoundError:
@@ -140,14 +299,14 @@ def get_value(root: int, path: str, value_name: str, default: Any | None = None)
         return default
 
 
-def key_exists(root: int, path: str) -> bool:
+def key_exists(root: int, path: str, *, view: str | None = None) -> bool:
     """!
-    @brief Determine whether the given key exists.
+    @brief Determine whether the given key exists for the requested view.
     """
 
     try:
         _ensure_winreg()
-        with open_key(root, path):
+        with open_key(root, path, view=view):
             return True
     except FileNotFoundError:
         return False
@@ -169,14 +328,173 @@ def hive_name(root: int) -> str:
     return mapping.get(root, hex(root))
 
 
+def looks_like_office_entry(values: Mapping[str, Any]) -> bool:
+    """!
+    @brief Determine whether an uninstall entry corresponds to Microsoft Office.
+    @details Heuristics focus on the ``DisplayName`` and ``Publisher`` fields,
+    mirroring OffScrub filters to target Office suites, Visio, Project, and
+    related SKUs.
+    """
+
+    display = str(values.get("DisplayName") or "").lower()
+    publisher = str(values.get("Publisher") or "").lower()
+    product_code = str(values.get("ProductCode") or "").upper()
+
+    if not display and not product_code:
+        return False
+
+    if publisher and "microsoft" not in publisher:
+        return False
+
+    for keyword in _OFFICE_KEYWORDS:
+        if keyword in display:
+            return True
+
+    if product_code.startswith("{901") or product_code.startswith("{911"):
+        return True
+
+    return False
+
+
+def iter_office_uninstall_entries(
+    roots: Iterable[Tuple[int, str]],
+    *,
+    view: str | None = None,
+) -> Iterator[Tuple[int, str, Dict[str, Any]]]:
+    """!
+    @brief Enumerate uninstall entries that resemble Office installations.
+    """
+
+    seen_paths: set[Tuple[int, str]] = set()
+    for hive, base_path in roots:
+        try:
+            subkeys = list(iter_subkeys(hive, base_path, view=view))
+        except FileNotFoundError:
+            continue
+
+        for subkey in subkeys:
+            relative_path = f"{base_path}\\{subkey}"
+            if (hive, relative_path) in seen_paths:
+                continue
+            values = read_values(hive, relative_path, view=view)
+            if not values:
+                continue
+            if looks_like_office_entry(values):
+                seen_paths.add((hive, relative_path))
+                yield hive, relative_path, values
+
+
+def _safe_export_filename(key: str) -> str:
+    """!
+    @brief Generate a filesystem-safe filename for registry exports.
+    """
+
+    canonical = _normalize_registry_key(key)
+    token = canonical.replace("\\", "_").upper()
+    token = _SAFE_FILENAME_PATTERN.sub("_", token)
+    token = token.strip("_") or "REGISTRY_EXPORT"
+    return f"{token}.reg"
+
+
+def _unique_export_path(directory: Path, key: str) -> Path:
+    """!
+    @brief Determine a unique path for the registry export file.
+    """
+
+    base_name = _safe_export_filename(key)
+    candidate = directory / base_name
+    counter = 1
+    while candidate.exists():
+        candidate = directory / f"{base_name[:-4]}_{counter}.reg"
+        counter += 1
+    return candidate
+
+
+def export_keys(
+    keys: Iterable[str],
+    destination: str | Path,
+    *,
+    dry_run: bool = False,
+    logger: logging.Logger | None = None,
+) -> List[Path]:
+    """!
+    @brief Export the provided registry keys to ``.reg`` files in ``destination``.
+    @details On non-Windows systems the exports become placeholder files so unit
+    tests and dry-run flows can still verify orchestration logic without access
+    to the native ``reg.exe`` utility.
+    """
+
+    logger = logger or _LOGGER
+    dest_path = Path(destination)
+    dest_path.mkdir(parents=True, exist_ok=True)
+
+    canonical_keys = _validate_registry_keys(keys)
+    reg_executable = shutil.which("reg")
+    exported: List[Path] = []
+
+    for key in canonical_keys:
+        export_path = _unique_export_path(dest_path, key)
+        logger.info(
+            "Preparing registry export",
+            extra={"action": "registry-export", "key": key, "path": str(export_path), "dry_run": dry_run},
+        )
+        if dry_run:
+            exported.append(export_path)
+            continue
+
+        if reg_executable:
+            subprocess.run(
+                [reg_executable, "export", key, str(export_path), "/y"],
+                check=True,
+            )
+            exported.append(export_path)
+            continue
+
+        export_path.write_text(
+            f"; Placeholder export for {key}\n",
+            encoding="utf-8",
+        )
+        exported.append(export_path)
+
+    return exported
+
+
+def delete_keys(
+    keys: Iterable[str],
+    *,
+    dry_run: bool = False,
+    logger: logging.Logger | None = None,
+) -> None:
+    """!
+    @brief Remove registry keys while respecting dry-run safeguards.
+    """
+
+    logger = logger or _LOGGER
+    canonical_keys = _validate_registry_keys(keys)
+    reg_executable = shutil.which("reg")
+
+    for key in canonical_keys:
+        logger.info(
+            "Preparing registry deletion",
+            extra={"action": "registry-delete", "key": key, "dry_run": dry_run},
+        )
+        if dry_run or not reg_executable:
+            continue
+        subprocess.run([reg_executable, "delete", key, "/f"], check=True)
+
+
 __all__ = [
+    "RegistryError",
     "delete_keys",
     "export_keys",
     "get_value",
     "hive_name",
+    "iter_office_uninstall_entries",
     "iter_subkeys",
     "iter_values",
     "key_exists",
+    "looks_like_office_entry",
     "open_key",
     "read_values",
 ]
+

--- a/tests/test_registry_tools.py
+++ b/tests/test_registry_tools.py
@@ -1,14 +1,17 @@
 """!
 @brief Registry tooling tests covering cleanup utilities.
-@details Validates dry-run behaviour and command invocation for registry export
-and delete helpers using mocked ``reg.exe`` availability.
+@details Validates dry-run behaviour, guardrails, and command invocation for
+registry export and delete helpers using mocked ``reg.exe`` availability. The
+tests also cover Office uninstall heuristics exposed by the module.
 """
 
 from __future__ import annotations
 
 import pathlib
 import sys
-from typing import List
+from typing import Iterable, List, Tuple
+
+import pytest
 
 PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
 SRC_PATH = PROJECT_ROOT / "src"
@@ -27,6 +30,23 @@ class _Result:
         self.returncode = returncode
 
 
+class _Recorder:
+    """!
+    @brief Minimal logger stub capturing emitted events.
+    """
+
+    def __init__(self) -> None:
+        self.messages: List[Tuple[str, dict]] = []
+
+    def info(self, message: str, *args, **kwargs) -> None:  # noqa: D401 - logging compatibility
+        payload = kwargs.copy()
+        self.messages.append((message, payload))
+
+    def warning(self, message: str, *args, **kwargs) -> None:  # noqa: D401 - logging compatibility
+        payload = kwargs.copy()
+        self.messages.append((message, payload))
+
+
 def test_delete_keys_invokes_reg_when_available(monkeypatch) -> None:
     """!
     @brief Deletion should call ``reg delete`` when the binary exists.
@@ -42,9 +62,13 @@ def test_delete_keys_invokes_reg_when_available(monkeypatch) -> None:
 
     monkeypatch.setattr(registry_tools.subprocess, "run", fake_run)
 
-    registry_tools.delete_keys(["HKLM\\Software\\Contoso"], dry_run=False)
+    registry_tools.delete_keys(
+        ["HKLM\\Software\\Microsoft\\Office\\Contoso"],
+        dry_run=False,
+        logger=_Recorder(),
+    )
 
-    assert commands == [["reg.exe", "delete", "HKLM\\Software\\Contoso", "/f"]]
+    assert commands == [["reg.exe", "delete", "HKLM\\SOFTWARE\\MICROSOFT\\OFFICE\\CONTOSO", "/f"]]
 
 
 def test_delete_keys_dry_run_skips_execution(monkeypatch) -> None:
@@ -59,7 +83,22 @@ def test_delete_keys_dry_run_skips_execution(monkeypatch) -> None:
 
     monkeypatch.setattr(registry_tools.subprocess, "run", fake_run)
 
-    registry_tools.delete_keys(["HKCU\\Software\\Tailspin"], dry_run=True)
+    registry_tools.delete_keys(
+        ["HKCU\\Software\\Microsoft\\Office\\Tailspin"],
+        dry_run=True,
+        logger=_Recorder(),
+    )
+
+
+def test_delete_keys_rejects_disallowed_paths(monkeypatch) -> None:
+    """!
+    @brief Guardrails should reject deletions outside the whitelist.
+    """
+
+    monkeypatch.setattr(registry_tools.shutil, "which", lambda exe: "reg.exe")
+
+    with pytest.raises(registry_tools.RegistryError):
+        registry_tools.delete_keys(["HKLM\\Software\\Contoso"], dry_run=False, logger=_Recorder())
 
 
 def test_export_keys_creates_placeholder_when_reg_missing(tmp_path, monkeypatch) -> None:
@@ -69,8 +108,78 @@ def test_export_keys_creates_placeholder_when_reg_missing(tmp_path, monkeypatch)
 
     monkeypatch.setattr(registry_tools.shutil, "which", lambda exe: None)
 
-    registry_tools.export_keys(["HKLM\\Software\\Fabrikam"], str(tmp_path))
+    recorder = _Recorder()
+    exported = registry_tools.export_keys(
+        ["HKLM\\Software\\Microsoft\\Office\\Fabrikam"],
+        tmp_path,
+        logger=recorder,
+    )
 
-    export_file = tmp_path / "HKLM_Software_Fabrikam.reg"
+    assert exported, "Expected an export path to be returned"
+    export_file = exported[0]
     assert export_file.exists()
     assert "Placeholder export" in export_file.read_text(encoding="utf-8")
+    assert recorder.messages and recorder.messages[0][1]["extra"]["action"] == "registry-export"
+
+
+def test_export_keys_dry_run_records_intent(tmp_path, monkeypatch) -> None:
+    """!
+    @brief Dry-run exports should log intent without creating files.
+    """
+
+    monkeypatch.setattr(registry_tools.shutil, "which", lambda exe: "reg.exe")
+
+    recorder = _Recorder()
+    exported = registry_tools.export_keys(
+        ["HKLM\\Software\\Microsoft\\Office\\Diagnostics"],
+        tmp_path,
+        dry_run=True,
+        logger=recorder,
+    )
+
+    assert exported
+    assert not exported[0].exists()
+    assert recorder.messages[0][1]["extra"]["dry_run"] is True
+
+
+def test_looks_like_office_entry_matches_keywords() -> None:
+    """!
+    @brief The Office heuristic should recognise branded display names.
+    """
+
+    entry = {"DisplayName": "Microsoft Office 365 ProPlus", "Publisher": "Microsoft Corporation"}
+    assert registry_tools.looks_like_office_entry(entry)
+
+    unrelated = {"DisplayName": "Contoso Widget", "Publisher": "Contoso"}
+    assert not registry_tools.looks_like_office_entry(unrelated)
+
+
+def test_iter_office_uninstall_entries_filters_non_office(monkeypatch) -> None:
+    """!
+    @brief Only Office-like entries should be returned from uninstall enumeration.
+    """
+
+    roots: Iterable[Tuple[int, str]] = [(0x80000002, r"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall")]
+
+    def fake_iter_subkeys(root: int, path: str, *, view: str | None = None):
+        yield from ("{90160000-0011-0000-0000-0000000FF1CE}", "ContosoApp")
+
+    def fake_read_values(root: int, path: str, *, view: str | None = None):
+        if path.endswith("ContosoApp"):
+            return {"DisplayName": "Contoso", "Publisher": "Contoso"}
+        return {
+            "DisplayName": "Microsoft Office Professional Plus 2016",
+            "Publisher": "Microsoft Corporation",
+            "ProductCode": "{90160000-0011-0000-0000-0000000FF1CE}",
+        }
+
+    monkeypatch.setattr(registry_tools, "iter_subkeys", fake_iter_subkeys)
+    monkeypatch.setattr(registry_tools, "read_values", fake_read_values)
+
+    results = list(registry_tools.iter_office_uninstall_entries(roots))
+    assert len(results) == 1
+    hive, path, values = results[0]
+    assert hive == 0x80000002
+    assert path.endswith("{90160000-0011-0000-0000-0000000FF1CE}")
+    assert values["ProductCode"] == "{90160000-0011-0000-0000-0000000FF1CE}"
+


### PR DESCRIPTION
## Summary
- add view-aware registry helpers with canonical key normalization and Office uninstall heuristics
- enforce safety guardrails for export/delete operations while adding logging hooks and sanitized filenames
- extend registry tooling tests to cover guardrails, dry-run behaviour, and Office detection helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fea604d7088325a0e68cabd736042e