### PR TITLE
Add shared command runner and expand Office uninstall flows

### DIFF
--- a/src/office_janitor/__init__.py
+++ b/src/office_janitor/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "processes",
     "tasks_services",
     "logging_ext",
+    "command_runner",
     "restore_point",
     "ui",
     "tui",

--- a/src/office_janitor/c2r_uninstall.py
+++ b/src/office_janitor/c2r_uninstall.py
@@ -1,160 +1,380 @@
 """!
 @brief Click-to-Run uninstall orchestration utilities.
-@details Mirrors the Click-to-Run OffScrub flow by composing the same VBS helper
-invocations as the reference ``OfficeScrubber.cmd`` script while retaining the
-project's structured logging and dry-run guarantees.
+@details Stops supporting services, prefers ``OfficeC2RClient.exe`` for removal,
+falls back to ``setup.exe`` when necessary, and verifies registry/file system
+state to confirm the Click-to-Run footprint has been removed.
 """
 from __future__ import annotations
 
-import subprocess
 import time
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Mapping, Sequence
+from typing import List, Mapping, MutableMapping, Sequence
 
-from . import constants, logging_ext
+from . import command_runner, constants, logging_ext, registry_tools, tasks_services
 
-OFFSCRUB_C2R_ARGS = constants.C2R_OFFSCRUB_ARGS
+C2R_CLIENT_ARGS = (
+    "/updatepromptuser=False",
+    "/uninstallpromptuser=False",
+    "/uninstall",
+    "/displaylevel=False",
+)
 """!
-@brief Backwards-compatible alias for Click-to-Run OffScrub arguments.
+@brief Arguments passed to ``OfficeC2RClient.exe`` to trigger silent uninstall.
 """
-from .off_scrub_scripts import ensure_offscrub_script
+
+C2R_CLIENT_CANDIDATES = (
+    Path(r"C:\\Program Files\\Common Files\\Microsoft Shared\\ClickToRun\\OfficeC2RClient.exe"),
+    Path(r"C:\\Program Files (x86)\\Common Files\\Microsoft Shared\\ClickToRun\\OfficeC2RClient.exe"),
+)
+"""!
+@brief Default filesystem locations checked for ``OfficeC2RClient.exe``.
+"""
+
+C2R_SETUP_CANDIDATES = (
+    Path(r"C:\\Program Files\\Common Files\\Microsoft Shared\\ClickToRun\\setup.exe"),
+    Path(r"C:\\Program Files (x86)\\Common Files\\Microsoft Shared\\ClickToRun\\setup.exe"),
+)
+"""!
+@brief Default filesystem locations checked for ``setup.exe`` fallback.
+"""
 
 C2R_TIMEOUT = 3600
 """!
-@brief Timeout (seconds) for Click-to-Run removal operations.
+@brief Default timeout for Click-to-Run uninstall commands.
+"""
+
+C2R_RETRY_ATTEMPTS = 1
+"""!
+@brief Number of retries after the initial uninstall attempt when using ``OfficeC2RClient.exe``.
+"""
+
+C2R_RETRY_DELAY = 10.0
+"""!
+@brief Delay between Click-to-Run uninstall retries in seconds.
+"""
+
+C2R_VERIFICATION_ATTEMPTS = 3
+"""!
+@brief Number of verification probes issued after uninstall commands complete.
+"""
+
+C2R_VERIFICATION_DELAY = 5.0
+"""!
+@brief Delay between verification probes for Click-to-Run removal.
 """
 
 
-def _collect_release_ids(raw: Iterable[str] | Sequence[str] | str | None) -> List[str]:
+@dataclass
+class _C2RTarget:
     """!
-    @brief Normalise Click-to-Run release identifiers into a list.
+    @brief Normalised metadata for a Click-to-Run uninstall target.
+    """
+
+    display_name: str
+    release_ids: Sequence[str]
+    uninstall_handles: Sequence[str]
+    install_paths: Sequence[Path]
+    client_candidates: Sequence[Path]
+    setup_candidates: Sequence[Path]
+
+
+def _collect_release_ids(raw: object) -> List[str]:
+    """!
+    @brief Normalise release identifier metadata into a list of strings.
     """
 
     if raw is None:
         return []
     if isinstance(raw, str):
-        return [item.strip() for item in raw.split(",") if item.strip()]
-    return [str(item).strip() for item in raw if str(item).strip()]
+        return [part.strip() for part in raw.replace(";", ",").split(",") if part.strip()]
+    if isinstance(raw, Sequence):
+        items: List[str] = []
+        for value in raw:
+            text = str(value).strip()
+            if text:
+                items.append(text)
+        return items
+    return []
 
 
-def build_command(
-    config: Mapping[str, object],
-    *,
-    script_directory: Path | None = None,
-) -> List[str]:
+def _normalise_c2r_entry(config: Mapping[str, object]) -> _C2RTarget:
     """!
-    @brief Compose the OffScrub Click-to-Run command for the given inventory entry.
+    @brief Convert a configuration mapping into a :class:`_C2RTarget` record.
     """
 
+    mapping: MutableMapping[str, object] = dict(config)
+    properties = mapping.get("properties")
+    property_map = dict(properties) if isinstance(properties, Mapping) else {}
+
     release_ids = _collect_release_ids(
-        config.get("release_ids")
-        or config.get("products")
-        or config.get("ProductReleaseIds")
+        mapping.get("release_ids")
+        or mapping.get("products")
+        or mapping.get("ProductReleaseIds")
+        or property_map.get("release_id")
+        or property_map.get("release_ids")
+    )
+    if not release_ids:
+        single = mapping.get("release_id") or property_map.get("release_id")
+        if single:
+            text = str(single).strip()
+            if text:
+                release_ids = [text]
+
+    display_name = str(
+        mapping.get("product")
+        or property_map.get("product")
+        or (", ".join(release_ids) if release_ids else "Click-to-Run Suite")
     )
 
-    script_path = ensure_offscrub_script(
-        constants.C2R_OFFSCRUB_SCRIPT, base_directory=script_directory
+    uninstall_handles: Sequence[str] = ()
+    raw_handles = mapping.get("uninstall_handles")
+    if isinstance(raw_handles, Sequence) and not isinstance(raw_handles, (str, bytes)):
+        uninstall_handles = [str(handle).strip() for handle in raw_handles if str(handle).strip()]
+
+    install_paths: List[Path] = []
+    for candidate in (
+        mapping.get("install_path"),
+        property_map.get("install_path"),
+        property_map.get("ClientFolder"),
+    ):
+        if not candidate:
+            continue
+        try:
+            path = Path(str(candidate)).expanduser()
+        except (TypeError, ValueError):
+            continue
+        install_paths.append(path)
+
+    client_candidates: List[Path] = []
+    raw_client = mapping.get("client_path") or property_map.get("client_path")
+    if raw_client:
+        client_candidates.append(Path(str(raw_client)))
+    raw_client_paths = mapping.get("client_paths") or property_map.get("client_paths")
+    if isinstance(raw_client_paths, Sequence) and not isinstance(raw_client_paths, (str, bytes)):
+        for value in raw_client_paths:
+            try:
+                client_candidates.append(Path(str(value)))
+            except (TypeError, ValueError):
+                continue
+    for base in install_paths:
+        client_candidates.append(base / "OfficeC2RClient.exe")
+    client_candidates.extend(C2R_CLIENT_CANDIDATES)
+
+    setup_candidates: List[Path] = []
+    raw_setup = mapping.get("setup_path") or property_map.get("setup_path")
+    if raw_setup:
+        setup_candidates.append(Path(str(raw_setup)))
+    raw_setup_paths = mapping.get("setup_paths") or property_map.get("setup_paths")
+    if isinstance(raw_setup_paths, Sequence) and not isinstance(raw_setup_paths, (str, bytes)):
+        for value in raw_setup_paths:
+            try:
+                setup_candidates.append(Path(str(value)))
+            except (TypeError, ValueError):
+                continue
+    for base in install_paths:
+        setup_candidates.append(base / "setup.exe")
+    setup_candidates.extend(C2R_SETUP_CANDIDATES)
+
+    return _C2RTarget(
+        display_name=display_name,
+        release_ids=tuple(dict.fromkeys(release_ids)),
+        uninstall_handles=tuple(uninstall_handles),
+        install_paths=tuple(dict.fromkeys(install_paths)),
+        client_candidates=tuple(dict.fromkeys(client_candidates)),
+        setup_candidates=tuple(dict.fromkeys(setup_candidates)),
     )
 
-    command: List[str] = [str(constants.OFFSCRUB_EXECUTABLE)]
-    command.extend(str(arg) for arg in constants.OFFSCRUB_HOST_ARGS)
-    command.append(str(script_path))
-    command.extend(constants.C2R_OFFSCRUB_ARGS)
-    if release_ids:
-        command.append(f"/PRODUCTS={';'.join(release_ids)}")
-    return command
 
-
-def uninstall_products(config: Mapping[str, object], *, dry_run: bool = False) -> None:
+def _parse_registry_handle(handle: str) -> tuple[int, str] | None:
     """!
-    @brief Trigger Click-to-Run OffScrub helpers for the supplied configuration.
+    @brief Parse ``HKLM\\`` style handles into hive/path tuples.
+    """
+
+    cleaned = str(handle).strip()
+    if not cleaned or "\\" not in cleaned:
+        return None
+    prefix, _, path = cleaned.partition("\\")
+    hive = constants.REGISTRY_ROOTS.get(prefix.upper())
+    if hive is None or not path:
+        return None
+    return hive, path
+
+
+def _handles_present(target: _C2RTarget) -> bool:
+    """!
+    @brief Check whether any uninstall handles remain in the registry.
+    """
+
+    for handle in target.uninstall_handles:
+        parsed = _parse_registry_handle(handle)
+        if parsed and registry_tools.key_exists(parsed[0], parsed[1]):
+            return True
+    return False
+
+
+def _install_paths_present(target: _C2RTarget) -> bool:
+    """!
+    @brief Check whether the recorded install paths still exist on disk.
+    """
+
+    for path in target.install_paths:
+        try:
+            if path.exists():
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _await_removal(target: _C2RTarget) -> bool:
+    """!
+    @brief Poll registry and filesystem to confirm Click-to-Run removal.
     """
 
     human_logger = logging_ext.get_human_logger()
     machine_logger = logging_ext.get_machine_logger()
 
-    command = build_command(config)
-    release_ids = _collect_release_ids(config.get("release_ids") or config.get("products"))
+    for attempt in range(1, C2R_VERIFICATION_ATTEMPTS + 1):
+        registry_present = _handles_present(target)
+        filesystem_present = _install_paths_present(target)
+        machine_logger.info(
+            "c2r_uninstall_verify",
+            extra={
+                "event": "c2r_uninstall_verify",
+                "release_ids": list(target.release_ids) or None,
+                "attempt": attempt,
+                "registry_present": registry_present,
+                "filesystem_present": filesystem_present,
+            },
+        )
+        if not registry_present and not filesystem_present:
+            human_logger.info(
+                "Confirmed Click-to-Run removal for %s", target.display_name
+            )
+            return True
+        if attempt < C2R_VERIFICATION_ATTEMPTS:
+            time.sleep(C2R_VERIFICATION_DELAY)
+    return False
 
+
+def _find_existing_path(candidates: Sequence[Path]) -> Path | None:
+    """!
+    @brief Return the first existing path from ``candidates``.
+    """
+
+    for candidate in candidates:
+        try:
+            if candidate.exists():
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def uninstall_products(
+    config: Mapping[str, object],
+    *,
+    dry_run: bool = False,
+    retries: int = C2R_RETRY_ATTEMPTS,
+) -> None:
+    """!
+    @brief Remove Click-to-Run installations using the preferred tooling.
+    @details Services are stopped before invoking ``OfficeC2RClient.exe`` with
+    retry semantics. If the client is unavailable the fallback ``setup.exe`` is
+    invoked per release identifier. Post-uninstall verification checks registry
+    handles and install paths, raising :class:`RuntimeError` when residue
+    remains.
+    @param config Inventory mapping describing the Click-to-Run suite.
+    @param dry_run When ``True`` log planned actions without executing commands.
+    @param retries Additional attempts after the first failure when using the
+    client executable.
+    """
+
+    human_logger = logging_ext.get_human_logger()
+    machine_logger = logging_ext.get_machine_logger()
+
+    target = _normalise_c2r_entry(config)
     machine_logger.info(
         "c2r_uninstall_plan",
         extra={
             "event": "c2r_uninstall_plan",
-            "release_ids": release_ids or None,
+            "release_ids": list(target.release_ids) or None,
+            "display_name": target.display_name,
             "dry_run": bool(dry_run),
-            "command": command,
+            "handles": list(target.uninstall_handles),
+            "install_paths": [str(path) for path in target.install_paths],
         },
     )
+
+    if not dry_run:
+        human_logger.info("Stopping Click-to-Run related services prior to uninstall.")
+        tasks_services.stop_services(constants.KNOWN_SERVICES)
+    else:
+        human_logger.info(
+            "Dry-run: would stop Click-to-Run services %s",
+            ", ".join(constants.KNOWN_SERVICES),
+        )
+
+    client_path = _find_existing_path(target.client_candidates)
+    total_attempts = max(1, int(retries) + 1)
+
+    if client_path is not None:
+        command = [str(client_path), *C2R_CLIENT_ARGS]
+        result: command_runner.CommandResult | None = None
+        for attempt in range(1, total_attempts + 1):
+            message = (
+                "Uninstalling Click-to-Run suite %s [attempt %d/%d]"
+                % (target.display_name, attempt, total_attempts)
+            )
+            result = command_runner.run_command(
+                command,
+                event="c2r_uninstall",
+                timeout=C2R_TIMEOUT,
+                dry_run=dry_run,
+                human_message=message,
+                extra={
+                    "release_ids": list(target.release_ids) or None,
+                    "attempt": attempt,
+                    "attempts": total_attempts,
+                    "executable": str(client_path),
+                },
+            )
+            if result.skipped:
+                break
+            if result.returncode == 0:
+                break
+            if attempt < total_attempts:
+                human_logger.warning(
+                    "Retrying Click-to-Run uninstall via OfficeC2RClient.exe"
+                )
+                time.sleep(C2R_RETRY_DELAY)
+        if result is not None and not (result.skipped or dry_run) and result.returncode != 0:
+            raise RuntimeError("Click-to-Run uninstall failed via OfficeC2RClient.exe")
+    else:
+        setup_path = _find_existing_path(target.setup_candidates)
+        if setup_path is None:
+            raise FileNotFoundError("Neither OfficeC2RClient.exe nor setup.exe were found")
+        release_ids = list(target.release_ids) or ["ALL"]
+        for release_id in release_ids:
+            message = f"Uninstalling Click-to-Run release {release_id} via setup.exe"
+            command = [str(setup_path), "/uninstall", release_id]
+            result = command_runner.run_command(
+                command,
+                event="c2r_setup_uninstall",
+                timeout=C2R_TIMEOUT,
+                dry_run=dry_run,
+                human_message=message,
+                extra={
+                    "release_id": release_id,
+                    "executable": str(setup_path),
+                },
+            )
+            if not dry_run and result.returncode != 0:
+                raise RuntimeError(f"setup.exe uninstall failed for {release_id}")
 
     if dry_run:
-        human_logger.info("Dry-run: would invoke %s", " ".join(command))
         return
 
-    human_logger.info(
-        "Invoking OffScrubC2R helper for release identifiers: %s",
-        ", ".join(release_ids) if release_ids else "ALL",
-    )
-    start = time.monotonic()
-    try:
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            text=True,
-            timeout=C2R_TIMEOUT,
-            check=False,
-        )
-    except subprocess.TimeoutExpired as exc:
-        duration = time.monotonic() - start
-        human_logger.error(
-            "OffScrubC2R timed out after %.1fs for releases %s",
-            duration,
-            ", ".join(release_ids) if release_ids else "ALL",
-        )
-        machine_logger.error(
-            "c2r_uninstall_timeout",
-            extra={
-                "event": "c2r_uninstall_timeout",
-                "release_ids": release_ids or None,
-                "duration": duration,
-                "stdout": exc.stdout,
-                "stderr": exc.stderr,
-            },
-        )
-        raise RuntimeError("Click-to-Run uninstall timed out") from exc
-
-    duration = time.monotonic() - start
-    if result.returncode != 0:
-        human_logger.error(
-            "OffScrubC2R failed with exit code %s for releases %s",
-            result.returncode,
-            ", ".join(release_ids) if release_ids else "ALL",
-        )
-        machine_logger.error(
-            "c2r_uninstall_failure",
-            extra={
-                "event": "c2r_uninstall_failure",
-                "release_ids": release_ids or None,
-                "return_code": result.returncode,
-                "stdout": result.stdout,
-                "stderr": result.stderr,
-                "duration": duration,
-            },
-        )
-        raise RuntimeError("Click-to-Run uninstall failed")
-
-    human_logger.info(
-        "Successfully completed OffScrubC2R in %.1f seconds for releases %s.",
-        duration,
-        ", ".join(release_ids) if release_ids else "ALL",
-    )
-    machine_logger.info(
-        "c2r_uninstall_success",
-        extra={
-            "event": "c2r_uninstall_success",
-            "release_ids": release_ids or None,
-            "return_code": result.returncode,
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-            "duration": duration,
-        },
-    )
+    if not _await_removal(target):
+        raise RuntimeError("Click-to-Run removal verification failed")

--- a/src/office_janitor/command_runner.py
+++ b/src/office_janitor/command_runner.py
@@ -1,0 +1,191 @@
+"""!
+@brief Shared subprocess execution helpers.
+@details Provides a consistent wrapper around :func:`subprocess.run` that
+records structured telemetry for command invocations, including execution
+plans, durations, and failure metadata. Callers in the uninstall pipeline use
+this module so command logging stays uniform across MSI and Click-to-Run flows.
+"""
+from __future__ import annotations
+
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping, Sequence
+
+from . import logging_ext
+
+
+@dataclass
+class CommandResult:
+    """!
+    @brief Outcome metadata returned by :func:`run_command`.
+    @details Captures the executed command, return code, collected streams, and
+    runtime characteristics. ``skipped`` is ``True`` when dry-run mode bypassed
+    the subprocess execution. ``timed_out`` is ``True`` when the command exceeded
+    the requested timeout.
+    """
+
+    command: Sequence[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    duration: float
+    skipped: bool = False
+    timed_out: bool = False
+    error: str | None = None
+
+
+def run_command(
+    command: Sequence[str],
+    *,
+    event: str,
+    timeout: int | float | None = None,
+    dry_run: bool = False,
+    human_message: str | None = None,
+    extra: Mapping[str, object] | None = None,
+) -> CommandResult:
+    """!
+    @brief Execute ``command`` while emitting structured telemetry records.
+    @details The helper logs a ``*_plan`` event prior to invocation and a
+    ``*_result`` event once the process exits (or a ``*_timeout``/``*_missing``
+    failure). Human-oriented messaging is routed through the human logger so the
+    console output mirrors the machine telemetry.
+    @param command Command sequence to execute.
+    @param event Base event identifier recorded in machine logs.
+    @param timeout Optional timeout in seconds for the subprocess.
+    @param dry_run When ``True`` skip execution and return a ``skipped`` result.
+    @param human_message Optional message logged to the human channel before
+    execution.
+    @param extra Mapping merged into machine log ``extra`` payloads.
+    @returns :class:`CommandResult` describing the observed outcome.
+    """
+
+    human_logger = logging_ext.get_human_logger()
+    machine_logger = logging_ext.get_machine_logger()
+
+    command_list = [str(part) for part in command]
+    metadata: MutableMapping[str, object] = {"event": f"{event}_plan", "command": command_list}
+    if extra:
+        metadata.update(extra)
+    machine_logger.info(f"{event}_plan", extra=dict(metadata))
+
+    if dry_run:
+        human_logger.info(
+            human_message or "Dry-run: would execute %s", " ".join(command_list)
+        )
+        dry_metadata: MutableMapping[str, object] = {
+            "event": f"{event}_dry_run",
+            "command": command_list,
+        }
+        if extra:
+            dry_metadata.update(extra)
+        machine_logger.info(f"{event}_dry_run", extra=dict(dry_metadata))
+        return CommandResult(
+            command=command_list,
+            returncode=0,
+            stdout="",
+            stderr="",
+            duration=0.0,
+            skipped=True,
+        )
+
+    if human_message:
+        human_logger.info(human_message)
+
+    start = time.monotonic()
+    try:
+        completed = subprocess.run(  # noqa: S603 - intentional command execution
+            command_list,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        duration = time.monotonic() - start
+        human_logger.error("Command not found: %s", command_list[0])
+        failure_meta: MutableMapping[str, object] = {
+            "event": f"{event}_missing",
+            "command": command_list,
+            "duration": duration,
+            "error": str(exc),
+        }
+        if extra:
+            failure_meta.update(extra)
+        machine_logger.error(f"{event}_missing", extra=dict(failure_meta))
+        return CommandResult(
+            command=command_list,
+            returncode=127,
+            stdout="",
+            stderr="",
+            duration=duration,
+            error=str(exc),
+        )
+    except subprocess.TimeoutExpired as exc:
+        duration = time.monotonic() - start
+        human_logger.error("Command timed out after %.1fs: %s", duration, command_list[0])
+        failure_meta = {
+            "event": f"{event}_timeout",
+            "command": command_list,
+            "duration": duration,
+            "stdout": exc.stdout or "",
+            "stderr": exc.stderr or "",
+        }
+        if extra:
+            failure_meta.update(extra)
+        machine_logger.error(f"{event}_timeout", extra=dict(failure_meta))
+        return CommandResult(
+            command=command_list,
+            returncode=1,
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or "",
+            duration=duration,
+            timed_out=True,
+            error="timeout",
+        )
+    except OSError as exc:
+        duration = time.monotonic() - start
+        human_logger.error("Failed to execute %s: %s", command_list[0], exc)
+        failure_meta = {
+            "event": f"{event}_error",
+            "command": command_list,
+            "duration": duration,
+            "error": str(exc),
+        }
+        if extra:
+            failure_meta.update(extra)
+        machine_logger.error(f"{event}_error", extra=dict(failure_meta))
+        return CommandResult(
+            command=command_list,
+            returncode=1,
+            stdout="",
+            stderr="",
+            duration=duration,
+            error=str(exc),
+        )
+
+    duration = time.monotonic() - start
+    result_meta: MutableMapping[str, object] = {
+        "event": f"{event}_result",
+        "command": command_list,
+        "return_code": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "duration": duration,
+    }
+    if extra:
+        result_meta.update(extra)
+    machine_logger.info(f"{event}_result", extra=dict(result_meta))
+
+    if completed.returncode != 0:
+        human_logger.warning(
+            "Command %s exited with %s", command_list[0], completed.returncode
+        )
+
+    return CommandResult(
+        command=command_list,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        duration=duration,
+    )

--- a/tests/test_uninstallers.py
+++ b/tests/test_uninstallers.py
@@ -1,16 +1,15 @@
 """!
-@brief Command composition and dry-run tests for uninstall helpers.
-@details Validates that the OffScrub wrappers constructed by
-:mod:`msi_uninstall` and :mod:`c2r_uninstall` mirror the reference
-``OfficeScrubber.cmd`` command lines, honour dry-run semantics, and raise when
-helpers fail.
+@brief Validate uninstall helper command composition and retry behaviour.
+@details Ensures :mod:`msi_uninstall` and :mod:`c2r_uninstall` build the
+expected ``msiexec``/Click-to-Run commands, honour dry-run semantics, and
+surface failures through informative exceptions.
 """
 
 from __future__ import annotations
 
 import pathlib
 import sys
-from typing import List
+from typing import List, Tuple
 
 import pytest
 
@@ -19,125 +18,265 @@ SRC_PATH = PROJECT_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
-from office_janitor import c2r_uninstall, logging_ext, msi_uninstall
+from office_janitor import c2r_uninstall, command_runner, logging_ext, msi_uninstall
 
 
-class _Result:
+def _command_result(command: List[str], returncode: int = 0, *, skipped: bool = False) -> command_runner.CommandResult:
     """!
-    @brief Simple stand-in for :class:`subprocess.CompletedProcess`.
+    @brief Convenience factory for :class:`CommandResult` instances.
     """
 
-    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
-        self.returncode = returncode
-        self.stdout = stdout
-        self.stderr = stderr
+    return command_runner.CommandResult(
+        command=command,
+        returncode=returncode,
+        stdout="",
+        stderr="",
+        duration=0.1,
+        skipped=skipped,
+    )
 
 
-def test_msi_uninstall_invokes_offscrub(monkeypatch, tmp_path) -> None:
+def test_msi_uninstall_builds_msiexec_command(monkeypatch, tmp_path) -> None:
     """!
-    @brief Ensure MSI uninstall helper constructs the OffScrub command line.
+    @brief Ensure ``msiexec`` commands are constructed and verification runs.
     """
 
     logging_ext.setup_logging(tmp_path)
-    calls: List[List[str]] = []
+    executed: List[List[str]] = []
+    state = {"present": True}
 
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return _Result()
+    def fake_run_command(
+        command: List[str],
+        *,
+        event: str,
+        timeout: float | None = None,
+        dry_run: bool = False,
+        human_message: str | None = None,
+        extra: dict | None = None,
+    ) -> command_runner.CommandResult:
+        executed.append(command)
+        state["present"] = False
+        return _command_result(command)
 
-    monkeypatch.setattr(msi_uninstall.subprocess, "run", fake_run)
-    record = {"product_code": "{91160000-0011-0000-0000-0000000FF1CE}", "version": "2019"}
+    monkeypatch.setattr(msi_uninstall.command_runner, "run_command", fake_run_command)
+    monkeypatch.setattr(msi_uninstall.registry_tools, "key_exists", lambda *_, **__: state["present"])
+    monkeypatch.setattr(msi_uninstall.time, "sleep", lambda *_: None)
+
+    record = {
+        "product": "Office",
+        "product_code": "{91160000-0011-0000-0000-0000000FF1CE}",
+        "uninstall_handles": [
+            "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{91160000-0011-0000-0000-0000000FF1CE}"
+        ],
+    }
     msi_uninstall.uninstall_products([record])
 
-    assert calls, "Expected OffScrub helper to be invoked"
-    command = calls[0]
-    assert command[0].lower().endswith("cscript.exe")
-    assert command[1] == "//NoLogo"
-    assert command[2].endswith("OffScrub_O16msi.vbs")
-    for arg in msi_uninstall.OFFSCRUB_BASE_ARGS:
-        assert arg in command
-    assert any(item.startswith("/PRODUCTCODE=") for item in command)
+    assert executed, "Expected msiexec to be invoked"
+    command = executed[0]
+    assert command[0].lower().endswith("msiexec.exe")
+    assert command[1] == "/x"
+    assert command[2].startswith("{")
+    assert "/qb!" in command
+    assert "/norestart" in command
 
 
-def test_msi_uninstall_respects_dry_run(monkeypatch, tmp_path) -> None:
+def test_msi_uninstall_dry_run(monkeypatch, tmp_path) -> None:
     """!
-    @brief Dry-run mode should skip OffScrub execution.
+    @brief Dry-run mode should record the plan without executing ``msiexec``.
     """
 
     logging_ext.setup_logging(tmp_path)
     called = False
 
-    def fake_run(cmd, **kwargs):
+    def fake_run_command(
+        command: List[str],
+        *,
+        event: str,
+        timeout: float | None = None,
+        dry_run: bool = False,
+        human_message: str | None = None,
+        extra: dict | None = None,
+    ) -> command_runner.CommandResult:
         nonlocal called
         called = True
-        return _Result()
+        assert dry_run is True
+        return _command_result(command, skipped=True)
 
-    monkeypatch.setattr(msi_uninstall.subprocess, "run", fake_run)
+    monkeypatch.setattr(msi_uninstall.command_runner, "run_command", fake_run_command)
+    monkeypatch.setattr(msi_uninstall.registry_tools, "key_exists", lambda *_, **__: True)
+
     msi_uninstall.uninstall_products(
-        [{"product_code": "{91160000-0011-0000-0000-0000000FF1CE}", "version": "2016"}],
+        [
+            {
+                "product": "Office",
+                "product_code": "{91160000-0011-0000-0000-0000000FF1CE}",
+            }
+        ],
         dry_run=True,
     )
 
-    assert not called, "Dry-run should not invoke OffScrub"
+    assert called, "Dry-run should still build the command"
 
 
-def test_msi_uninstall_reports_failures(monkeypatch, tmp_path) -> None:
+def test_msi_uninstall_reports_failure(monkeypatch, tmp_path) -> None:
     """!
-    @brief Non-zero exit codes should raise an informative error.
+    @brief Non-zero return codes propagate as ``RuntimeError`` instances.
     """
 
     logging_ext.setup_logging(tmp_path)
 
-    def fake_run(cmd, **kwargs):
-        return _Result(returncode=1603)
+    def fake_run_command(
+        command: List[str],
+        *,
+        event: str,
+        timeout: float | None = None,
+        dry_run: bool = False,
+        human_message: str | None = None,
+        extra: dict | None = None,
+    ) -> command_runner.CommandResult:
+        return _command_result(command, returncode=1603)
 
-    monkeypatch.setattr(msi_uninstall.subprocess, "run", fake_run)
+    monkeypatch.setattr(msi_uninstall.command_runner, "run_command", fake_run_command)
+    monkeypatch.setattr(msi_uninstall.registry_tools, "key_exists", lambda *_, **__: True)
 
     with pytest.raises(RuntimeError) as excinfo:
-        msi_uninstall.uninstall_products([{"product_code": "{BAD-CODE}", "version": "2013"}])
+        msi_uninstall.uninstall_products(["{BAD-CODE}"])
 
     assert "BAD-CODE" in str(excinfo.value)
 
 
-def test_c2r_uninstall_constructs_command(monkeypatch, tmp_path) -> None:
+def test_c2r_uninstall_prefers_client(monkeypatch, tmp_path) -> None:
     """!
-    @brief Validate Click-to-Run OffScrub command composition and logging.
+    @brief OfficeC2RClient.exe should be preferred when available.
     """
 
     logging_ext.setup_logging(tmp_path)
-    calls: List[List[str]] = []
+    executed: List[Tuple[List[str], dict]] = []
+    state = {"present": True}
 
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return _Result()
+    def fake_run_command(
+        command: List[str],
+        *,
+        event: str,
+        timeout: float | None = None,
+        dry_run: bool = False,
+        human_message: str | None = None,
+        extra: dict | None = None,
+    ) -> command_runner.CommandResult:
+        executed.append((command, extra or {}))
+        state["present"] = False
+        return _command_result(command)
 
-    monkeypatch.setattr(c2r_uninstall.subprocess, "run", fake_run)
+    monkeypatch.setattr(c2r_uninstall.command_runner, "run_command", fake_run_command)
+    monkeypatch.setattr(c2r_uninstall.tasks_services, "stop_services", lambda services, *, timeout=30: None)
+    monkeypatch.setattr(c2r_uninstall, "_handles_present", lambda target: state["present"])
+    monkeypatch.setattr(c2r_uninstall, "_install_paths_present", lambda target: state["present"])
+    monkeypatch.setattr(c2r_uninstall.time, "sleep", lambda *_: None)
 
-    config = {"release_ids": ["O365ProPlusRetail", "VisioProRetail"]}
+    client_path = tmp_path / "OfficeC2RClient.exe"
+    client_path.write_text("")
+
+    config = {
+        "product": "Microsoft 365 Apps",
+        "release_ids": ["O365ProPlusRetail"],
+        "client_paths": [client_path],
+        "uninstall_handles": [
+            "HKLM\\SOFTWARE\\Microsoft\\Office\\ClickToRun\\ProductReleaseIDs\\O365ProPlusRetail"
+        ],
+        "install_path": str(tmp_path),
+    }
+
     c2r_uninstall.uninstall_products(config)
 
-    assert calls, "Expected OffScrubC2R helper to be invoked"
-    command = calls[0]
-    assert command[0].lower().endswith("cscript.exe")
-    assert command[2].endswith("OffScrubC2R.vbs")
-    assert set(c2r_uninstall.OFFSCRUB_C2R_ARGS).issubset(command)
-    assert any(item.startswith("/PRODUCTS=") for item in command)
+    assert executed, "Expected OfficeC2RClient.exe invocation"
+    command, metadata = executed[0]
+    assert command[0].endswith("OfficeC2RClient.exe")
+    for arg in c2r_uninstall.C2R_CLIENT_ARGS:
+        assert arg in command
+    assert metadata.get("executable", "").endswith("OfficeC2RClient.exe")
+
+
+def test_c2r_uninstall_fallback_to_setup(monkeypatch, tmp_path) -> None:
+    """!
+    @brief ``setup.exe`` fallback should run when the client is missing.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    executed: List[List[str]] = []
+    state = {"present": True}
+
+    def fake_run_command(
+        command: List[str],
+        *,
+        event: str,
+        timeout: float | None = None,
+        dry_run: bool = False,
+        human_message: str | None = None,
+        extra: dict | None = None,
+    ) -> command_runner.CommandResult:
+        executed.append(command)
+        state["present"] = False
+        return _command_result(command)
+
+    monkeypatch.setattr(c2r_uninstall.command_runner, "run_command", fake_run_command)
+    monkeypatch.setattr(c2r_uninstall.tasks_services, "stop_services", lambda services, *, timeout=30: None)
+    monkeypatch.setattr(c2r_uninstall, "_handles_present", lambda target: state["present"])
+    monkeypatch.setattr(c2r_uninstall, "_install_paths_present", lambda target: state["present"])
+    monkeypatch.setattr(c2r_uninstall.time, "sleep", lambda *_: None)
+
+    setup_path = tmp_path / "setup.exe"
+    setup_path.write_text("")
+
+    config = {
+        "release_ids": ["O365ProPlusRetail", "VisioProRetail"],
+        "setup_paths": [setup_path],
+        "install_path": str(tmp_path),
+    }
+
+    c2r_uninstall.uninstall_products(config)
+
+    assert executed, "Expected setup.exe invocation"
+    assert all(cmd[0].endswith("setup.exe") for cmd in executed)
+    assert {cmd[2] for cmd in executed} == {"O365ProPlusRetail", "VisioProRetail"}
 
 
 def test_c2r_uninstall_dry_run(monkeypatch, tmp_path) -> None:
     """!
-    @brief Dry-run skips OffScrubC2R execution.
+    @brief Dry-run should not stop services or verify removal.
     """
 
     logging_ext.setup_logging(tmp_path)
-    called = False
+    executed: List[List[str]] = []
 
-    def fake_run(cmd, **kwargs):
-        nonlocal called
-        called = True
-        return _Result()
+    def fake_run_command(
+        command: List[str],
+        *,
+        event: str,
+        timeout: float | None = None,
+        dry_run: bool = False,
+        human_message: str | None = None,
+        extra: dict | None = None,
+    ) -> command_runner.CommandResult:
+        executed.append(command)
+        return _command_result(command, skipped=True)
 
-    monkeypatch.setattr(c2r_uninstall.subprocess, "run", fake_run)
-    c2r_uninstall.uninstall_products({"release_ids": ["Test"]}, dry_run=True)
+    monkeypatch.setattr(c2r_uninstall.command_runner, "run_command", fake_run_command)
 
-    assert not called, "Dry-run should not invoke OffScrubC2R"
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("Services should not stop in dry-run")
+
+    monkeypatch.setattr(c2r_uninstall.tasks_services, "stop_services", fail_if_called)
+    monkeypatch.setattr(c2r_uninstall.registry_tools, "key_exists", lambda *_, **__: True)
+
+    client_path = tmp_path / "OfficeC2RClient.exe"
+    client_path.write_text("")
+
+    c2r_uninstall.uninstall_products(
+        {
+            "release_ids": ["O365ProPlusRetail"],
+            "client_paths": [client_path],
+        },
+        dry_run=True,
+    )
+
+    assert executed, "Dry-run should still build a command"


### PR DESCRIPTION
## Summary
- add a shared command runner helper that records plan/result events with durations and errors
- rework MSI uninstall orchestration to drive msiexec with retries and registry verification
- update Click-to-Run uninstall to stop services, prefer OfficeC2RClient.exe with setup.exe fallback, and confirm removal via probes
- extend uninstall tests to exercise the new command paths and dry-run handling

## Testing
- pytest tests/test_uninstallers.py

------
https://chatgpt.com/codex/tasks/task_e_68ff946e356083259db29f1e39765b5f