### PR TITLE
Improve restore point orchestration

### DIFF
--- a/src/office_janitor/restore_point.py
+++ b/src/office_janitor/restore_point.py
@@ -1,50 +1,207 @@
 """!
-@brief System restore point management.
-@details Creates restore points prior to destructive operations when supported,
-providing optional rollback coverage per the specification.
+@brief System restore point management utilities.
+@details Coordinates PowerShell/WMI calls to create restore points prior to
+running destructive operations. The helpers provide structured logging, dry-run
+simulation, and defensive error handling so callers can safely request restore
+coverage when available.
 """
 from __future__ import annotations
 
+import json
+import os
 import subprocess
+import textwrap
+from typing import Sequence
 
 from . import logging_ext
 
 
-def create_restore_point(description: str) -> None:
+_POWERSHELL_EXECUTABLE = "powershell.exe"
+_POWERSHELL_TIMEOUT_SECONDS = 180
+
+
+def create_restore_point(
+    description: str,
+    *,
+    dry_run: bool = False,
+    timeout: int = _POWERSHELL_TIMEOUT_SECONDS,
+) -> bool:
     """!
     @brief Request a system restore point with the supplied description.
+    @details Uses PowerShell to invoke the ``SystemRestore`` WMI provider, falling
+    back to ``Checkpoint-Computer`` if the class is unavailable. When ``dry_run``
+    is enabled the function emits simulation telemetry without invoking
+    PowerShell. Failures are logged but suppressed so callers can continue with
+    additional guardrails (e.g., ``--force``).
+    @param description Human-readable text describing the restore point.
+    @param dry_run Whether to simulate the request without executing PowerShell.
+    @param timeout Maximum time to wait for PowerShell before aborting.
+    @returns ``True`` if the restore point was created (or simulated), ``False``
+    otherwise.
     """
+
     human_logger = logging_ext.get_human_logger()
+    machine_logger = logging_ext.get_machine_logger()
 
-    command = [
-        "powershell.exe",
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        (
-            "Checkpoint-Computer -Description \"{}\" "
-            "-RestorePointType 'MODIFY_SETTINGS'".format(description.replace("\"", "'"))
-        ),
-    ]
+    description_text = description or "Office Janitor restore point"
 
-    human_logger.info("Creating system restore point: %s", description)
+    machine_logger.info(
+        "restore_point.request",
+        extra={
+            "event": "restore_point.request",
+            "description": description_text,
+            "dry_run": dry_run,
+        },
+    )
+
+    if dry_run:
+        human_logger.info(
+            "Dry-run enabled; would create system restore point: %s",
+            description_text,
+        )
+        machine_logger.info(
+            "restore_point.skipped",
+            extra={
+                "event": "restore_point.skipped",
+                "reason": "dry_run",
+                "description": description_text,
+            },
+        )
+        return True
+
+    if os.name != "nt":
+        human_logger.info(
+            "Restore points are only available on Windows hosts; skipping request.",
+        )
+        machine_logger.warning(
+            "restore_point.unsupported_platform",
+            extra={
+                "event": "restore_point.unsupported_platform",
+                "platform": os.name,
+            },
+        )
+        return False
+
+    command = _build_powershell_command(description_text)
 
     try:
         result = subprocess.run(
             command,
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=max(1, int(timeout)),
             check=False,
         )
-    except FileNotFoundError:  # pragma: no cover - Windows-specific command.
-        human_logger.debug("powershell.exe unavailable; skipping restore point creation")
-        return
-
-    if result.returncode != 0:
+    except FileNotFoundError:
         human_logger.warning(
-            "Restore point creation returned %s: %s",
-            result.returncode,
-            result.stderr.strip(),
+            "%s unavailable; skipping system restore point creation.",
+            _POWERSHELL_EXECUTABLE,
         )
+        machine_logger.warning(
+            "restore_point.unavailable",
+            extra={
+                "event": "restore_point.unavailable",
+                "reason": "missing_powershell",
+                "executable": _POWERSHELL_EXECUTABLE,
+            },
+        )
+        return False
+    except subprocess.TimeoutExpired:
+        human_logger.warning(
+            "System restore point creation timed out after %s seconds.", timeout
+        )
+        machine_logger.warning(
+            "restore_point.timeout",
+            extra={
+                "event": "restore_point.timeout",
+                "timeout": int(timeout),
+            },
+        )
+        return False
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        human_logger.warning("Unexpected restore point failure: %s", exc)
+        machine_logger.warning(
+            "restore_point.error",
+            extra={
+                "event": "restore_point.error",
+                "error": repr(exc),
+            },
+        )
+        return False
+
+    stderr = (result.stderr or "").strip()
+    stdout = (result.stdout or "").strip()
+
+    if result.returncode == 0:
+        human_logger.info("System restore point created: %s", description_text)
+        machine_logger.info(
+            "restore_point.success",
+            extra={
+                "event": "restore_point.success",
+                "description": description_text,
+                "stdout": stdout,
+            },
+        )
+        return True
+
+    human_logger.warning(
+        "Restore point creation returned %s: %s",
+        result.returncode,
+        stderr or stdout or "(no error output)",
+    )
+    machine_logger.warning(
+        "restore_point.failed",
+        extra={
+            "event": "restore_point.failed",
+            "code": int(result.returncode),
+            "stderr": stderr,
+            "stdout": stdout,
+        },
+    )
+    return False
+
+
+def _build_powershell_command(description: str) -> Sequence[str]:
+    """!
+    @brief Construct the PowerShell command used to create a restore point.
+    @details The generated script attempts the WMI ``SystemRestore`` path first
+    to avoid policy blocks on ``Checkpoint-Computer``. If that fails the script
+    falls back to ``Checkpoint-Computer`` before surfacing an error.
+    @param description Description string for the restore point.
+    @returns Sequence suitable for :func:`subprocess.run`.
+    """
+
+    description_literal = json.dumps(description)
+    script = textwrap.dedent(
+        f"""
+        $description = {description_literal}
+        $restorePointType = 0
+        $eventType = 100
+        try {{
+            $systemRestore = Get-WmiObject -Class SystemRestore -Namespace \"root/default\" -ErrorAction Stop
+            $result = $systemRestore.CreateRestorePoint($description, $restorePointType, $eventType)
+            if ($result.ReturnValue -eq 0) {{
+                exit 0
+            }}
+            exit $result.ReturnValue
+        }} catch {{
+            try {{
+                Checkpoint-Computer -Description $description -RestorePointType 'MODIFY_SETTINGS' -ErrorAction Stop | Out-Null
+                exit 0
+            }} catch {{
+                $message = $_.Exception.Message
+                Write-Error $message
+                exit 1
+            }}
+        }}
+        """
+    ).strip()
+
+    return [
+        _POWERSHELL_EXECUTABLE,
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        script,
+    ]

--- a/src/office_janitor/scrub.py
+++ b/src/office_janitor/scrub.py
@@ -423,15 +423,20 @@ def execute_plan(
         },
     )
 
+    should_request_restore_point = bool(
+        options.get("create_restore_point") or options.get("restore_point")
+    )
+    if should_request_restore_point:
+        try:
+            restore_point.create_restore_point(
+                "Office Janitor pre-cleanup", dry_run=global_dry_run
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            human_logger.warning("Failed to create restore point: %s", exc)
+
     if global_dry_run:
         human_logger.info("Executing plan in dry-run mode; no destructive actions will occur.")
     else:
-        if options.get("create_restore_point") or options.get("restore_point"):
-            try:
-                restore_point.create_restore_point("Office Janitor pre-cleanup")
-            except Exception as exc:  # pragma: no cover - defensive logging
-                human_logger.warning("Failed to create restore point: %s", exc)
-
         processes.terminate_office_processes(constants.DEFAULT_OFFICE_PROCESSES)
         processes.terminate_process_patterns(constants.OFFICE_PROCESS_PATTERNS)
         tasks_services.stop_services(constants.KNOWN_SERVICES)


### PR DESCRIPTION
## Summary
- implement a restore point helper that uses PowerShell/WMI with structured logging, dry-run handling, and defensive error reporting
- invoke the helper from the scrub orchestrator so --no-restore-point and dry-run simulation are honored consistently
- expand restore point unit tests to cover WMI command construction and dry-run behaviour

## Testing
- pytest tests/test_scrub.py
- pytest tests/test_cleanup_tools.py -k restore_point

------
https://chatgpt.com/codex/tasks/task_e_69009c13f978832599c233c9c29ff172