### PR TITLE
Queue locked filesystem deletions for Office cleanup

### DIFF
--- a/tests/test_fs_tools.py
+++ b/tests/test_fs_tools.py
@@ -7,6 +7,7 @@ directory resolution implemented in :mod:`office_janitor.fs_tools`.
 from __future__ import annotations
 
 import pathlib
+import types
 import sys
 
 PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -112,6 +113,135 @@ def test_backup_path_dry_run(tmp_path, monkeypatch) -> None:
 
     assert created is not None
     assert not destination.exists()
+
+
+def test_schedule_delete_on_reboot_uses_movefileex(tmp_path, monkeypatch) -> None:
+    """!
+    @brief ``MoveFileExW`` should be used when available to queue deletions.
+    """
+
+    class _FakeMoveFileEx:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str | None, int]] = []
+            self.argtypes = ()
+            self.restype = None
+
+        def __call__(self, source: str, destination: str | None, flags: int) -> int:
+            self.calls.append((source, destination, flags))
+            return 1
+
+    fake_move = _FakeMoveFileEx()
+
+    class _FakeKernel32:
+        def __init__(self, move) -> None:
+            self.MoveFileExW = move
+
+    fake_ctypes = types.SimpleNamespace(
+        windll=types.SimpleNamespace(kernel32=_FakeKernel32(fake_move)),
+        c_wchar_p=str,
+        c_uint=int,
+        c_int=int,
+        get_last_error=lambda: 0,
+    )
+
+    monkeypatch.setattr(fs_tools, "ctypes", fake_ctypes)
+    monkeypatch.setattr(fs_tools.os, "name", "nt")
+    monkeypatch.setattr(fs_tools.logging_ext, "get_human_logger", lambda: _NullLogger())
+    monkeypatch.setattr(fs_tools.logging_ext, "get_machine_logger", lambda: _NullLogger())
+
+    target = tmp_path / "locked.txt"
+    result = fs_tools._schedule_delete_on_reboot(target)
+
+    assert result is True
+    assert fake_move.calls == [(str(target), None, fs_tools._MOVEFILE_DELAY_UNTIL_REBOOT)]
+
+
+def test_schedule_delete_on_reboot_registry_fallback(tmp_path, monkeypatch) -> None:
+    """!
+    @brief Registry updates should be used when ``MoveFileExW`` is unavailable.
+    """
+
+    class _FakeHandle:
+        def __init__(self, registry) -> None:
+            self._registry = registry
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    class _FakeWinReg:
+        def __init__(self) -> None:
+            self.values: dict[str, tuple[int, list[str]]] = {}
+            self.HKEY_LOCAL_MACHINE = object()
+            self.KEY_READ = 0x1
+            self.KEY_SET_VALUE = 0x2
+            self.REG_MULTI_SZ = 7
+
+        def ConnectRegistry(self, _machine, _root):
+            return _FakeHandle(self)
+
+        def OpenKey(self, _registry, _subkey, _reserved, _access):
+            return _FakeHandle(self)
+
+        def QueryValueEx(self, _key, value_name):
+            if value_name in self.values:
+                stored = self.values[value_name]
+                return stored[1], stored[0]
+            raise FileNotFoundError
+
+        def SetValueEx(self, _key, value_name, _reserved, regtype, value):
+            self.values[value_name] = (regtype, list(value))
+
+    fake_winreg = _FakeWinReg()
+
+    monkeypatch.setattr(fs_tools, "ctypes", types.SimpleNamespace(windll=types.SimpleNamespace()))
+    monkeypatch.setattr(fs_tools, "winreg", fake_winreg)
+    monkeypatch.setattr(fs_tools.os, "name", "nt")
+    monkeypatch.setattr(fs_tools.logging_ext, "get_human_logger", lambda: _NullLogger())
+    monkeypatch.setattr(fs_tools.logging_ext, "get_machine_logger", lambda: _NullLogger())
+
+    target = tmp_path / "delayed"
+    result = fs_tools._schedule_delete_on_reboot(target)
+
+    assert result is True
+    stored = fake_winreg.values[fs_tools._PENDING_FILE_RENAME_VALUE][1]
+    assert stored[-2:] == [str(target), ""]
+
+
+def test_remove_paths_schedules_on_permission_error(tmp_path, monkeypatch) -> None:
+    """!
+    @brief Removal failures should queue a deferred deletion request.
+    """
+
+    target = tmp_path / "blocked.txt"
+    target.write_text("payload", encoding="utf-8")
+
+    calls: list[pathlib.Path] = []
+
+    def _fake_schedule(path: pathlib.Path, *, dry_run: bool, human_logger, machine_logger) -> bool:
+        calls.append(path)
+        return True
+
+    original_unlink = pathlib.Path.unlink
+
+    def _failing_unlink(self, *args, **kwargs):  # pragma: no cover - signature passthrough
+        if self == target:
+            raise PermissionError("locked")
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(fs_tools, "make_paths_writable", lambda _paths, **_kwargs: None)
+    monkeypatch.setattr(fs_tools, "reset_acl", lambda _path: None)
+    monkeypatch.setattr(fs_tools, "_schedule_delete_on_reboot", _fake_schedule)
+    monkeypatch.setattr(pathlib.Path, "unlink", _failing_unlink)
+    monkeypatch.setattr(fs_tools.logging_ext, "get_human_logger", lambda: _NullLogger())
+    monkeypatch.setattr(fs_tools.logging_ext, "get_machine_logger", lambda: _NullLogger())
+
+    fs_tools.remove_paths([target])
+
+    assert calls == [target]
+    assert target.exists()
 
 
 def test_get_default_log_directory_prefers_programdata(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add a reboot-queue helper in `fs_tools` that calls `MoveFileExW` or updates `PendingFileRenameOperations` when immediate deletion fails
- extend `remove_paths` to log and schedule delayed deletes while keeping dry-run behaviour informative
- add pytest coverage that monkeypatches ctypes/registry shims to exercise the new scheduling paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6906a89d97c483259f656b793085e9cb