### PR TITLE
Add disk space guard to safety runtime evaluation

### DIFF
--- a/src/office_janitor/main.py
+++ b/src/office_janitor/main.py
@@ -573,6 +573,10 @@ def _enforce_runtime_guards(options: Mapping[str, object], *, dry_run: bool) -> 
         restore_point_available=restore_point_available,
         force=bool(options.get("force", False)),
         allow_unsupported_windows=bool(options.get("allow_unsupported_windows", False)),
+        minimum_free_space_bytes=options.get("minimum_free_space_bytes"),
+        disk_usage_root=options.get("disk_usage_root")
+        or options.get("free_space_root")
+        or options.get("system_drive"),
     )
 
 


### PR DESCRIPTION
## Summary
- add a default minimum free-space guard to the safety runtime evaluation flow
- allow plan/runtime options to override the disk usage root or free-space threshold
- extend the safety test suite with disk-usage fixtures and coverage for success, failure, and force overrides

## Testing
- pytest tests/test_safety.py

------
https://chatgpt.com/codex/tasks/task_e_6907344315848325952101bc2e9b7bf9