### PR TITLE
Relay Outlook reassurance warning through logs and UI events

### DIFF
--- a/src/office_janitor/main.py
+++ b/src/office_janitor/main.py
@@ -315,6 +315,8 @@ def _build_app_state(
             record["data"] = dict(payload)
         ui_events.append(record)
 
+    logging_ext.register_ui_event_sink(emitter=emit_event, queue=ui_events)
+
     def detector() -> dict:
         logdir_path = pathlib.Path(getattr(args, "logdir", _resolve_log_directory(None))).expanduser()
         return _run_detection(machine_log, logdir_path)

--- a/src/office_janitor/processes.py
+++ b/src/office_janitor/processes.py
@@ -130,6 +130,18 @@ def prompt_user_to_close(
     question = "Proceed with forced termination? [y/N]: "
     human_logger.warning(message)
 
+    normalized = {name.lower() for name in remaining}
+    if "outlook.exe" in normalized:
+        reassurance = (
+            "Outlook data providers are only suspended; OST/PST mail stores remain intact."
+        )
+        human_logger.warning(reassurance)
+        logging_ext.emit_ui_event(
+            "processes.outlook_reassurance",
+            reassurance,
+            status="Outlook data providers suspended; OST/PST files remain intact.",
+        )
+
     for attempt in range(attempts):
         response = input_func(question).strip().lower()
         if response in {"y", "yes"}:


### PR DESCRIPTION
## Summary
- add logging helpers to register and emit UI events so background modules can surface messages
- warn operators that Outlook data providers are only suspended before forcing termination and emit the reassurance event
- cover the new warning with a test that inspects the human log and event queue when Outlook is active

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_6907378ba6b48325bba7ffe50f7a6174