### PR TITLE
Add setup.exe fallback for MSI uninstalls

### DIFF
--- a/src/office_janitor/msi_uninstall.py
+++ b/src/office_janitor/msi_uninstall.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+import os
+from pathlib import Path
+import shlex
 import sys
 from typing import Callable, Iterable, List, Mapping, MutableMapping, Sequence, Tuple
 
@@ -71,6 +74,7 @@ class _MsiProduct:
     display_name: str
     version: str
     uninstall_handles: Sequence[str]
+    maintenance_executable: str | None = None
 
 
 def _normalise_product_code(raw: str) -> str:
@@ -98,6 +102,94 @@ def _default_handles_for_code(product_code: str) -> List[str]:
     for hive, base in registry_roots:
         handles.append(f"{registry_tools.hive_name(hive)}\\{base}\\{product_code}")
     return handles
+
+
+def _strip_icon_index(raw: str) -> str:
+    """!
+    @brief Remove trailing icon index fragments from registry values.
+    """
+
+    text = raw.strip()
+    if "," not in text:
+        return text
+    prefix, _, suffix = text.partition(",")
+    remainder = suffix.strip()
+    if remainder and not remainder.lstrip("+-").isdigit():
+        return text
+    return prefix
+
+
+def _extract_setup_candidate(value: object) -> str:
+    """!
+    @brief Attempt to extract a ``setup.exe`` path from ``value``.
+    """
+
+    if value is None:
+        return ""
+    text = _strip_icon_index(str(value).strip())
+    if not text or "setup.exe" not in text.lower():
+        return ""
+    cleaned_text = text.strip().strip('"').strip()
+    candidates: List[str] = []
+    if cleaned_text:
+        candidates.append(cleaned_text)
+    try:
+        parts = shlex.split(text, posix=False)
+    except ValueError:
+        parts = []
+    if parts:
+        candidates.extend(parts)
+    for token in candidates:
+        cleaned = token.strip().strip('"').strip()
+        if not cleaned:
+            continue
+        lowered = cleaned.lower()
+        if lowered.endswith("setup.exe"):
+            return cleaned
+        if "setup.exe" in lowered:
+            index = lowered.find("setup.exe")
+            return cleaned[: index + len("setup.exe")]
+    return ""
+
+
+def _normalise_maintenance_paths(*sources: object) -> Tuple[str, ...]:
+    """!
+    @brief Normalise a collection of maintenance path hints into unique strings.
+    """
+
+    collected: List[str] = []
+    for source in sources:
+        if not source:
+            continue
+        if isinstance(source, (list, tuple, set)):
+            for item in source:
+                candidate = _extract_setup_candidate(item)
+                if candidate and candidate not in collected:
+                    collected.append(candidate)
+        else:
+            candidate = _extract_setup_candidate(source)
+            if candidate and candidate not in collected:
+                collected.append(candidate)
+    return tuple(collected)
+
+
+def _select_existing_setup(paths: Sequence[str]) -> str | None:
+    """!
+    @brief Return the first existing ``setup.exe`` from ``paths``.
+    """
+
+    for raw in paths:
+        candidate = str(raw).strip().strip('"')
+        if not candidate:
+            continue
+        expanded = os.path.expanduser(os.path.expandvars(candidate))
+        path = Path(expanded)
+        try:
+            if path.is_file() and path.name.lower() == "setup.exe":
+                return str(path)
+        except OSError:
+            continue
+    return None
 
 
 def _normalise_product_entry(product: Mapping[str, object] | str) -> _MsiProduct:
@@ -150,11 +242,21 @@ def _normalise_product_entry(product: Mapping[str, object] | str) -> _MsiProduct
     if not handles:
         handles = _default_handles_for_code(product_code)
 
+    maintenance_paths = _normalise_maintenance_paths(
+        mapping.get("maintenance_paths"),
+        property_map.get("maintenance_paths"),
+        mapping.get("display_icon"),
+        property_map.get("display_icon"),
+        property_map.get("uninstall_string"),
+    )
+    maintenance_executable = _select_existing_setup(maintenance_paths)
+
     return _MsiProduct(
         product_code=product_code,
         display_name=display_name,
         version=version,
         uninstall_handles=tuple(handles),
+        maintenance_executable=maintenance_executable,
     )
 
 
@@ -312,10 +414,16 @@ def _handle_busy_installer(
     return True, delay
 
 
-def build_command(product_code: str) -> List[str]:
+def build_command(product_code: str, *, maintenance_executable: str | None = None) -> List[str]:
     """!
-    @brief Compose the ``msiexec`` command used to uninstall ``product_code``.
+    @brief Compose the command used to uninstall ``product_code``.
     """
+
+    if maintenance_executable:
+        cleaned = maintenance_executable.strip()
+        if not cleaned:
+            raise ValueError("maintenance_executable must be non-empty when provided")
+        return [cleaned, "/uninstall"]
 
     normalized = _normalise_product_code(product_code)
     if not normalized:
@@ -369,7 +477,7 @@ def uninstall_products(
     busy_input_func: Callable[[str], str] | None = None,
 ) -> None:
     """!
-    @brief Uninstall the supplied MSI products via ``msiexec``.
+    @brief Uninstall the supplied MSI products via ``msiexec`` or setup fallbacks.
     @details Each product is normalised, executed with retry semantics, and
     verified for removal using registry probes. Non-zero exit codes or failed
     verifications raise :class:`RuntimeError` summarising the offending product
@@ -407,6 +515,7 @@ def uninstall_products(
                 "version": entry.version,
                 "dry_run": bool(dry_run),
                 "handles": list(entry.uninstall_handles),
+                "maintenance_executable": entry.maintenance_executable,
             },
         )
 
@@ -418,17 +527,27 @@ def uninstall_products(
             )
             continue
 
-        command = build_command(entry.product_code)
+        command = build_command(
+            entry.product_code, maintenance_executable=entry.maintenance_executable
+        )
+        using_setup = bool(entry.maintenance_executable)
+        event_name = "msi_setup_uninstall" if using_setup else "msi_uninstall"
         result: command_runner.CommandResult | None = None
 
         for attempt in range(1, total_attempts + 1):
-            message = (
-                "Uninstalling MSI product %s (%s) [attempt %d/%d]"
-                % (entry.display_name, entry.product_code, attempt, total_attempts)
-            )
+            if using_setup:
+                message = (
+                    "Uninstalling MSI product %s (%s) via setup.exe [attempt %d/%d]"
+                    % (entry.display_name, entry.product_code, attempt, total_attempts)
+                )
+            else:
+                message = (
+                    "Uninstalling MSI product %s (%s) [attempt %d/%d]"
+                    % (entry.display_name, entry.product_code, attempt, total_attempts)
+                )
             result = command_runner.run_command(
                 command,
-                event="msi_uninstall",
+                event=event_name,
                 timeout=MSIEXEC_TIMEOUT,
                 dry_run=dry_run,
                 human_message=message,
@@ -438,6 +557,7 @@ def uninstall_products(
                     "version": entry.version,
                     "attempt": attempt,
                     "attempts": total_attempts,
+                    "executor": command[0] if command else None,
                 },
             )
             if result.skipped:
@@ -445,7 +565,8 @@ def uninstall_products(
             if result.returncode == 0:
                 break
             if (
-                result.returncode == MSI_BUSY_RETURN_CODE
+                not using_setup
+                and result.returncode == MSI_BUSY_RETURN_CODE
                 and attempt < total_attempts
                 and not dry_run
             ):
@@ -462,7 +583,10 @@ def uninstall_products(
                 break
             if attempt < total_attempts:
                 human_logger.warning(
-                    "Retrying msiexec for %s (%s)", entry.display_name, entry.product_code
+                    "Retrying %s for %s (%s)",
+                    command[0] if command else "uninstall",
+                    entry.display_name,
+                    entry.product_code,
                 )
                 time.sleep(MSI_RETRY_DELAY)
         else:
@@ -482,6 +606,7 @@ def uninstall_products(
                     "display_name": entry.display_name,
                     "version": entry.version,
                     "return_code": result.returncode,
+                    "executor": command[0] if command else None,
                 },
             )
             failures.append(entry.product_code)
@@ -489,7 +614,9 @@ def uninstall_products(
 
         if not _await_removal(entry):
             human_logger.error(
-                "Registry still reports %s (%s) after msiexec", entry.display_name, entry.product_code
+                "Registry still reports %s (%s) after uninstall command",
+                entry.display_name,
+                entry.product_code,
             )
             machine_logger.error(
                 "msi_uninstall_residue",
@@ -498,6 +625,7 @@ def uninstall_products(
                     "product_code": entry.product_code,
                     "display_name": entry.display_name,
                     "version": entry.version,
+                    "executor": command[0] if command else None,
                 },
             )
             failures.append(entry.product_code)

--- a/tests/test_uninstallers.py
+++ b/tests/test_uninstallers.py
@@ -80,6 +80,61 @@ def test_msi_uninstall_builds_msiexec_command(monkeypatch, tmp_path) -> None:
     assert "/norestart" in command
 
 
+def test_msi_uninstall_uses_setup_when_available(monkeypatch, tmp_path) -> None:
+    """!
+    @brief Setup-based maintenance executables should be preferred when present.
+    """
+
+    logging_ext.setup_logging(tmp_path)
+    executed: List[Tuple[List[str], str, bool]] = []
+    probe_states: List[bool] = []
+    state = {"present": True}
+
+    setup_path = tmp_path / "setup.exe"
+    setup_path.write_text("dummy")
+
+    def fake_run_command(
+        command: List[str],
+        *,
+        event: str,
+        timeout: float | None = None,
+        dry_run: bool = False,
+        human_message: str | None = None,
+        extra: dict | None = None,
+    ) -> command_runner.CommandResult:
+        executed.append((command, event, dry_run))
+        state["present"] = False
+        return _command_result(command)
+
+    def fake_key_exists(*_: object, **__: object) -> bool:
+        probe_states.append(state["present"])
+        return state["present"]
+
+    monkeypatch.setattr(msi_uninstall.command_runner, "run_command", fake_run_command)
+    monkeypatch.setattr(msi_uninstall.registry_tools, "key_exists", fake_key_exists)
+    monkeypatch.setattr(msi_uninstall.time, "sleep", lambda *_: None)
+
+    record = {
+        "product": "Office",
+        "product_code": "{91160000-0011-0000-0000-0000000FF1CE}",
+        "maintenance_paths": [str(setup_path)],
+        "properties": {
+            "maintenance_paths": [str(setup_path)],
+            "display_icon": f"{setup_path},0",
+        },
+    }
+
+    msi_uninstall.uninstall_products([record])
+
+    assert executed, "Expected setup.exe to be invoked"
+    command, event, dry_run = executed[0]
+    assert command[0] == str(setup_path)
+    assert command[1:] == ["/uninstall"]
+    assert event == "msi_setup_uninstall"
+    assert dry_run is False
+    assert False in probe_states, "Verification should observe removal state"
+
+
 def test_msi_uninstall_dry_run(monkeypatch, tmp_path) -> None:
     """!
     @brief Dry-run mode should record the plan without executing ``msiexec``.


### PR DESCRIPTION
## Summary
- capture registry DisplayIcon values and setup.exe maintenance candidates in MSI detection payloads
- teach the MSI uninstaller to invoke setup.exe with /uninstall when present while preserving logging, retries, and verification
- add unit tests covering DisplayIcon capture and the setup-based uninstall execution path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69089736232483258b1e695600ed76e0